### PR TITLE
Bump web3 version to 6.0 beta with support for websockets > 10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def setup_package():
         description="Spice.xyz client library - data and AI infrastructure for web3.",
         license="Apache 2.0",
         packages=["spicepy"],
-        install_requires=["pyarrow", "pandas", "web3"],
+        install_requires=["pyarrow", "pandas", "web3>=6.0.0b2"],
         python_requires=">=3.7",
     )
 


### PR DESCRIPTION
Kaggle comes with the python package `websockets` at version 10.3. The latest released version of [web3.py](https://pypi.org/project/web3/#history) (5.29.0) requires websockets less than version 10.

Bumping the web3 package version to the latest 6.0 beta will use the websocket version 10 package, requiring no changes to Kaggle.