### PR TITLE
Add back support for Python 3.7 to support Kaggle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
     name: Build on ${{ matrix.os }} with ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     name: Build on ${{ matrix.os }} with ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
     name: Test with pip install ${{ matrix.python-version }}
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     name: Test with pip install ${{ matrix.python-version }}
     steps:
       - name: Set up Python ${{ matrix.python-version }}
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     name: Test on ${{ matrix.os }} with pytest ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyarrow>=8.0
-pandas>=1.4
+pandas>=1.3.5
 web3>=6.0.0b2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyarrow>=8.0
 pandas>=1.3.5
-web3>=6.0.0b2
+web3>=5.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pyarrow>=8.0
 pandas>=1.3.5
-web3>=5.31.0

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def setup_package():
         license="Apache 2.0",
         packages=["spicepy"],
         install_requires=["pyarrow", "pandas", "web3>=6.0.0b2"],
-        python_requires=">=3.8",
+        python_requires=">=3.7",
     )
 
 

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -6,8 +6,6 @@ import tempfile
 from typing import Union
 from urllib.request import urlretrieve
 
-from web3 import Web3
-
 
 def is_macos_arm64() -> bool:
     return platform.platform().lower().startswith("macos") and platform.machine() == "arm64"
@@ -55,8 +53,6 @@ class Client:
         self._flight_client = flight.connect(url, tls_root_certs=self.root_cert)
         self._flight_options = flight.FlightCallOptions()
         self._authenticate()
-        self.w3 = Web3(Web3.HTTPProvider(  # pylint: disable=C0103
-            f"https://data.spiceai.io/eth?api_key={self._api_key}"))
 
     def _authenticate(self):
         headers = [self._flight_client.authenticate_basic_token("", self._api_key)]


### PR DESCRIPTION
Kaggle only runs with Python 3.7, so spicepy is broken on Kaggle by default.