### PR TITLE
Fixed client non-responsiveness to ctrl+c

### DIFF
--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -1,7 +1,9 @@
+import threading
 from pathlib import Path
 import platform
 from typing import Union
 import certifi
+from pyarrow._flight import FlightCallOptions, FlightClient, Ticket
 
 
 def is_macos_arm64() -> bool:
@@ -49,23 +51,60 @@ class Client:
 
     def query(self, query: str, **kwargs) -> flight.FlightStreamReader:
         timeout = kwargs.get("timeout", None)
+
         if timeout is not None:
             if not isinstance(timeout, int) or timeout <= 0:
                 raise ValueError("Timeout must be a positive integer")
             self._flight_options = flight.FlightCallOptions(headers=self.headers, timeout=timeout)
+
         flight_info = self._flight_client.get_flight_info(
             flight.FlightDescriptor.for_command(query), self._flight_options
         )
+
         try:
-            reader = self._flight_client.do_get(
-                flight_info.endpoints[0].ticket, self._flight_options
-            )
+            reader = self._threaded_flight_do_get(ticket=flight_info.endpoints[0].ticket)
         except flight.FlightUnauthenticatedError:
             self._authenticate()
-            reader = self._flight_client.do_get(
-                flight_info.endpoints[0].ticket, self._flight_options
-            )
+            reader = self._threaded_flight_do_get(ticket=flight_info.endpoints[0].ticket)
         except flight.FlightTimedOutError as exc:
             raise TimeoutError(f"Query timed out and was canceled after {timeout} seconds.") from exc
 
         return reader
+
+    def _threaded_flight_do_get(self, ticket: Ticket):
+        thread = _ArrowFlightCallThread(
+            ticket=ticket,
+            flight_options=self._flight_options,
+            flight_client=self._flight_client
+        )
+        thread.start()
+        while thread.is_alive():
+            thread.join(1)
+
+        return thread.reader
+
+
+class _ArrowFlightCallThread(threading.Thread):
+    def __init__(
+            self,
+            flight_client: FlightClient,
+            ticket: Ticket,
+            flight_options: FlightCallOptions
+    ):
+        super().__init__()
+        self._exc = None
+        self._flight_client = flight_client
+        self._ticket = ticket
+        self._flight_options = flight_options
+        self.reader = None
+
+    def run(self):
+        try:
+            self.reader = self._flight_client.do_get(self._ticket, self._flight_options)
+        except BaseException as e:
+            self._exc = e
+
+    def join(self, timeout=None):
+        super(_ArrowFlightCallThread, self).join(timeout)
+        if self._exc:
+            raise self._exc

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -1,9 +1,10 @@
-import threading
+import certifi
 from pathlib import Path
 import platform
+import threading
 from typing import Union
-import certifi
-from pyarrow._flight import FlightCallOptions, FlightClient, Ticket
+
+from pyarrow._flight import FlightCallOptions, FlightClient, Ticket  # pylint: disable=E0611
 
 
 def is_macos_arm64() -> bool:
@@ -101,10 +102,10 @@ class _ArrowFlightCallThread(threading.Thread):
     def run(self):
         try:
             self.reader = self._flight_client.do_get(self._ticket, self._flight_options)
-        except BaseException as e:
-            self._exc = e
+        except BaseException as exc:  # pylint: disable=W0718
+            self._exc = exc
 
     def join(self, timeout=None):
-        super(_ArrowFlightCallThread, self).join(timeout)
+        super().join(timeout)
         if self._exc:
             raise self._exc

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -1,9 +1,9 @@
-import certifi
 from pathlib import Path
 import platform
 import threading
 from typing import Union
 
+import certifi
 from pyarrow._flight import FlightCallOptions, FlightClient, Ticket  # pylint: disable=E0611
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -45,13 +45,7 @@ FROM eth.blocks limit 2000
 
 def test_timeout():
     client = get_test_client()
-    query = """
-select address, topics[0], topics[1], topics[2],
-row_number() over
-  (partition by address order by topics[0], topics[1], topics[2]) as r
-from eth.recent_logs
-order by address, r
-    """
+    query = """SELECT * FROM eth.logs ORDER BY block_number DESC"""
     try:
         _ = client.query(query, timeout=1)
         assert False


### PR DESCRIPTION
* Arrow call is now executed on a separate thread that can be successfully terminated with a keyboard interrupt
* Exceptions raised in the thread are successfully passed back to the main thread