### PR TITLE
Make api_key optional, for local spice runtime support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.11', '3.12']
     name: Build on ${{ matrix.os }} with ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.11', '3.12']
     name: Lint with pylint ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
+          cache: 'pip'
       - name: Install requirements
         run: |
           pip install ".[test]"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           spice init spice_qs
           cd spice_qs
-          Start-Process -FilePath spice add spiceai/quickstart
+          spice add spiceai/quickstart
           Start-Process -FilePath spice run
         shell: pwsh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,9 @@ jobs:
           spice init spice_qs
           cd spice_qs
           spice add spiceai/quickstart
-          Start-Process -FilePath spice run
+          spice run &> spice.log &
+          # time to initialize added dataset
+          sleep 10
 
       - name: Init and start spice app (Windows)
         if: matrix.os == 'windows-latest'
@@ -91,9 +93,7 @@ jobs:
           spice init spice_qs
           cd spice_qs
           spice add spiceai/quickstart
-          spice run &> spice.log &
-          # time to initialize added dataset
-          sleep 10
+          Start-Process -FilePath spice run
         shell: pwsh
 
       - name: Running tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ['3.11', '3.12']
     name: Test with pip install ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ['3.11', '3.12']
     name: Test on ${{ matrix.os }} with pytest ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
+          cache: 'pip'
       - name: Install requirements
         run: |
           pip install ".[test]"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,20 @@ jobs:
 
       - name: install Spice
         if: matrix.os != 'windows-latest'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
+          function curl() {
+            if [ -z "$GH_TOKEN" ]
+            then
+              command curl -H "Accept: application/vnd.github.v3.raw" \
+                $@
+            else
+              command curl -H "Accept: application/vnd.github.v3.raw" \
+                -H "Authorization: token $GH_TOKEN" \
+                $@
+            fi
+          }
           curl https://install.spiceai.org | /bin/bash
           echo "$HOME/.spice/bin" >> $GITHUB_PATH
 
@@ -65,6 +78,15 @@ jobs:
         shell: pwsh
 
       - name: Init and start spice app
+        if: matrix.os != 'windows-latest'
+        run: |
+          spice init spice_qs
+          cd spice_qs
+          spice add spiceai/quickstart
+          Start-Process -FilePath spice run
+
+      - name: Init and start spice app (Windows)
+        if: matrix.os == 'windows-latest'
         run: |
           spice init spice_qs
           cd spice_qs
@@ -72,6 +94,7 @@ jobs:
           spice run &> spice.log &
           # time to initialize added dataset
           sleep 10
+        shell: pwsh
 
       - name: Running tests
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     name: Test with pip install ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     name: Test on ${{ matrix.os }} with pytest ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
@@ -42,10 +42,25 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
       - name: Install requirements
         run: |
           pip install ".[test]"
+
+      - name: install Spice (https://install.spiceai.org)
+        run: |
+          curl https://install.spiceai.org | /bin/bash
+          echo "$HOME/.spice/bin" >> $GITHUB_PATH
+
+      - name: Init and start spice app
+        run: |
+          spice init spice_qs
+          cd spice_qs
+          spice add spiceai/quickstart
+          spice run &> spice.log &
+          # time to initialize added dataset
+          sleep 10
+
       - name: Running tests
         env:
           API_KEY: ${{ secrets.API_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     name: Test with pip install ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     name: Test on ${{ matrix.os }} with pytest ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           spice init spice_qs
           cd spice_qs
-          spice add spiceai/quickstart
+          Start-Process -FilePath spice add spiceai/quickstart
           Start-Process -FilePath spice run
         shell: pwsh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     name: Test with pip install ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     name: Test on ${{ matrix.os }} with pytest ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
@@ -42,15 +42,27 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
       - name: Install requirements
         run: |
           pip install ".[test]"
 
-      - name: install Spice (https://install.spiceai.org)
+      - name: install Spice
+        if: matrix.os != 'windows-latest'
         run: |
           curl https://install.spiceai.org | /bin/bash
           echo "$HOME/.spice/bin" >> $GITHUB_PATH
+
+      - name: install Spice (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          curl -L "https://install.spiceai.org/Install.ps1" -o Install.ps1 && PowerShell -ExecutionPolicy Bypass -File ./Install.ps1
+
+      - name: add Spice bin to PATH (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          Add-Content $env:GITHUB_PATH (Join-Path $HOME ".spice\bin")
+        shell: pwsh
 
       - name: Init and start spice app
         run: |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pd = data.read_pandas()
 from spicepy import Client
 
 client = Client(
-      api_key='API_KEY'
+      api_key='API_KEY',
       flight_url="grpc+tls://flight.spiceai.io"
 )
 data = client.query('SELECT * FROM eth.recent_blocks LIMIT 10;', timeout=5*60)
@@ -43,7 +43,7 @@ pd = data.read_pandas()
 from spicepy import Client
 
 client = Client(
-      api_key='API_KEY'
+      api_key='API_KEY',
       flight_url="grpc+tls://flight.spiceai.io"
 )
 data = client.fire_query('SELECT * FROM eth.recent_blocks LIMIT 10;', timeout=5*60)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install git+https://github.com/spiceai/spicepy@v1.0.1
 
 ### Arrow Query with local spice runtime
 
-Follow the [quiqstart guide](https://github.com/spiceai/spiceai?tab=readme-ov-file#%EF%B8%8F-quickstart-local-machine) to install and run spice locally
+Follow the [quickstart guide](https://github.com/spiceai/spiceai?tab=readme-ov-file#%EF%B8%8F-quickstart-local-machine) to install and run spice locally
 
 ```python
 from spicepy import Client

--- a/README.md
+++ b/README.md
@@ -10,14 +10,29 @@ pip install git+https://github.com/spiceai/spicepy@v1.0.1
 
 ## Usage
 
-### Arrow Query
+### Arrow Query with local spice runtime
+
+Follow the [quiqstart guide](https://github.com/spiceai/spiceai?tab=readme-ov-file#%EF%B8%8F-quickstart-local-machine) to install and run spice locally
+
+```python
+from spicepy import Client
+
+client = Client()
+data = client.query('SELECT trip_distance, total_amount FROM taxi_trips ORDER BY trip_distance DESC LIMIT 10;', timeout=5*60)
+pd = data.read_pandas()
+```
+
+### Arrow Query with spice.ai cloud
 
 **SQL Query**
 
 ```python
 from spicepy import Client
 
-client = Client('API_KEY')
+client = Client(
+      api_key='API_KEY'
+      flight_url="grpc+tls://flight.spiceai.io"
+)
 data = client.query('SELECT * FROM eth.recent_blocks LIMIT 10;', timeout=5*60)
 pd = data.read_pandas()
 ```
@@ -27,7 +42,10 @@ pd = data.read_pandas()
 ```python
 from spicepy import Client
 
-client = Client('API_KEY')
+client = Client(
+      api_key='API_KEY'
+      flight_url="grpc+tls://flight.spiceai.io"
+)
 data = client.fire_query('SELECT * FROM eth.recent_blocks LIMIT 10;', timeout=5*60)
 pd = data.read_pandas()
 ```
@@ -44,75 +62,6 @@ Once a `Client` is obtained queries can be made using the `query()` function. Th
 - **timeout** (int, optional): The timeout in seconds.
 
 A custom timeout can be set by passing the `timeout` parameter in the `query` function call. If no timeout is specified, it will default to a 10 min timeout then cancel the query, and a TimeoutError exception will be raised.
-
-### HTTP API
-#### Prices
-Get the latest price for a token pair.
-```python
->>> client.prices.get_latest("BTC-USDC")
-{'BTC-USDC': Quote(pair=None,
-                   prices={'binance': 26639.37},
-                   min_price=26639.37,
-                   max_price=26639.37,
-                   mean_price=26639.37)}
-```
-
-Get historical data 
-```python
->>> client.prices.get("BTC-USDC")
-{'BTC-USDC': [Price(timestamp=datetime.datetime(2023, 9, 22, 4, 20, tzinfo=datetime.timezone.utc),
-                    price=26642.77,
-                    high=26642.77,
-                    low=26633.98,
-                    open=26633.98,
-                    close=26642.77),
-              Price(timestamp=datetime.datetime(2023, 9, 22, 4, 25, tzinfo=datetime.timezone.utc),
-                    price=26631.46,
-                    high=26638.77,
-                    low=26631.46,
-                    open=26638.77,
-                    close=26631.46),
-              Price(timestamp=datetime.datetime(2023, 9, 22, 4, 30, tzinfo=datetime.timezone.utc),
-                    price=26639.61,
-                    high=26644.16,
-                    low=26634.41,
-                    open=26634.41,
-                    close=26627.63)]}
-```
-
-Support for multiple pairs and configurable time periods
-```python
->>> client.prices.get(["BTC-USDC", "ETH-BTC"],
-    start=datetime.now() - timedelta(days=7),
-    end=datetime.now() - timedelta(days=6),
-    granularity=timedelta(hours=12)
-)
-{'BTC-USDC': [Price(timestamp=datetime.datetime(2023, 9, 15, 12, 0, tzinfo=datetime.timezone.utc),
-                    price=26426.23,
-                    high=26686.76,
-                    low=26372.71,
-                    open=26526.38,
-                    close=26426.23),
-              Price(timestamp=datetime.datetime(2023, 9, 16, 0, 0, tzinfo=datetime.timezone.utc),
-                    price=26601.63,
-                    high=26886.13,
-                    low=26224.17,
-                    open=26407.31,
-                    close=26601.63)],
- 'ETH-BTC': [Price(timestamp=datetime.datetime(2023, 9, 15, 12, 0, tzinfo=datetime.timezone.utc),
-                   price=0.06127,
-                   high=0.06152,
-                   low=0.06116,
-                   open=0.06132,
-                   close=0.06127),
-             Price(timestamp=datetime.datetime(2023, 9, 16, 0, 0, tzinfo=datetime.timezone.utc),
-                   price=0.06166,
-                   high=0.06181,
-                   low=0.0613,
-                   open=0.06134,
-                   close=0.06166)]}
-
-```
 
 ## Documentation
 

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -6,8 +6,7 @@ from typing import Dict, Union
 
 import certifi
 from pyarrow._flight import FlightCallOptions, FlightClient, Ticket  # pylint: disable=E0611
-from ._http import HttpRequests
-from .error import SpiceAIError
+from ._http import HttpRequestsSpiceAIError
 from . import config
 
 

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -6,7 +6,7 @@ from typing import Dict, Union
 
 import certifi
 from pyarrow._flight import FlightCallOptions, FlightClient, Ticket  # pylint: disable=E0611
-from ._http import HttpRequestsSpiceAIError
+from ._http import HttpRequests
 from . import config
 
 

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -61,10 +61,16 @@ class _SpiceFlight:
         self._authenticate()
 
     def _authenticate(self):
-        self.headers = [self._flight_client.authenticate_basic_token("", self._api_key)]
-        self._flight_options = flight.FlightCallOptions(
-            headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS
-        )
+        if self._api_key is not None:
+            self.headers = [self._flight_client.authenticate_basic_token("", self._api_key)]
+            self._flight_options = flight.FlightCallOptions(
+                headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS
+            )
+        else:
+            self.headers = []
+            self._flight_options = flight.FlightCallOptions(
+                headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS
+            )
 
     def query(self, query: str, **kwargs) -> flight.FlightStreamReader:
         timeout = kwargs.get("timeout", None)
@@ -112,8 +118,8 @@ class _SpiceFlight:
 class Client:
     def __init__(
         self,
-        api_key: str,
-        flight_url: str = config.DEFAULT_FLIGHT_URL,
+        api_key: str = None,
+        flight_url: str = config.DEFAULT_LOCAL_FLIGHT_URL,
         firecache_url: str = config.DEFAULT_FIRECACHE_URL,
         http_url: str = config.DEFAULT_HTTP_URL,
         tls_root_cert: Union[str, Path, None] = None,
@@ -136,11 +142,6 @@ class Client:
         key = self.api_key
         if key is None:
             key = os.environ.get("SPICE_API_KEY")
-        if not key:
-            raise SpiceAIError(
-                "No API key provided. You need to set the SPICE_API_KEY environment variable or create a client "
-                "with `spicepy.Client('API_KEY')`. You can find your API key on at https://spice.ai."
-            )
         return key
 
     def query(self, query: str, **kwargs) -> flight.FlightStreamReader:

--- a/spicepy/config.py
+++ b/spicepy/config.py
@@ -3,3 +3,6 @@ import os
 DEFAULT_FLIGHT_URL = os.environ.get("SPICE_FLIGHT_URL", "grpc+tls://flight.spiceai.io")
 DEFAULT_FIRECACHE_URL = os.environ.get("SPICE_FIRECACHE_URL", "grpc+tls://firecache.spiceai.io")
 DEFAULT_HTTP_URL = os.environ.get("SPICE_HTTP_URL", "https://data.spiceai.io")
+
+DEFAULT_LOCAL_FLIGHT_URL = os.environ.get("SPICE_LOCAL_FLIGHT_URL", "grpc://localhost:50051")
+DEFAULT_LOCAL_HTTP_URL = os.environ.get("SPICE_LOCAL_HTTP_URL", "http://localhost:3000 ")

--- a/test.requirements.txt
+++ b/test.requirements.txt
@@ -1,3 +1,3 @@
-pylint==2.17.6
+pylint==3.1.0
 flake8==6.1.0
 pytest==7.4.2

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,27 +4,32 @@ import time
 from spicepy import Client
 
 
-def get_test_client():
+def get_cloud_client():
     api_key = os.environ["API_KEY"]
-    return Client(api_key)
+    return Client(
+        api_key=api_key,
+        flight_url="grpc+tls://flight.spiceai.io"
+    )
 
+def get_local_client():
+    return Client(flight_url="grpc://localhost:50051")
 
 def test_flight_recent_blocks():
-    client = get_test_client()
+    client = get_cloud_client()
     data = client.query("SELECT * FROM eth.recent_blocks LIMIT 10")
     pandas_data = data.read_pandas()
     assert len(pandas_data) == 10
 
 
 def test_firecache_recent_blocks():
-    client = get_test_client()
+    client = get_cloud_client()
     data = client.fire_query("SELECT * FROM eth.recent_blocks LIMIT 10")
     pandas_data = data.read_pandas()
     assert len(pandas_data) == 10
 
 
 def test_flight_streaming():
-    client = get_test_client()
+    client = get_cloud_client()
     query = """
 SELECT number,
        "timestamp",
@@ -52,7 +57,7 @@ FROM eth.blocks limit 2000
 
 
 def test_flight_timeout():
-    client = get_test_client()
+    client = get_cloud_client()
     query = """SELECT block_number,
        TO_TIMESTAMP(block_timestamp) as block_timestamp,
        avg(gas) as avg_gas_used,
@@ -76,9 +81,15 @@ ORDER BY block_number DESC"""
     except TimeoutError:
         assert True
 
+def test_local_runtime():
+    client = get_local_client()
+    data = client.query("SELECT * FROM taxi_trips LIMIT 10")
+    pandas_data = data.read_pandas()
+    assert len(pandas_data) == 10
 
 if __name__ == "__main__":
     test_flight_recent_blocks()
     test_firecache_recent_blocks()
     test_flight_streaming()
     test_flight_timeout()
+    test_local_runtime()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,8 +11,10 @@ def get_cloud_client():
         flight_url="grpc+tls://flight.spiceai.io"
     )
 
+
 def get_local_client():
     return Client(flight_url="grpc://localhost:50051")
+
 
 def test_flight_recent_blocks():
     client = get_cloud_client()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -81,11 +81,13 @@ ORDER BY block_number DESC"""
     except TimeoutError:
         assert True
 
+
 def test_local_runtime():
     client = get_local_client()
     data = client.query("SELECT * FROM taxi_trips LIMIT 10")
     pandas_data = data.read_pandas()
     assert len(pandas_data) == 10
+
 
 if __name__ == "__main__":
     test_flight_recent_blocks()


### PR DESCRIPTION
closes #85 
closes #78 

Made the `api_key` optional in the `spicepy.Client` class, enabling support for local Spice runtime connections.

```py

from spicepy import Client

# will use local connection by default
client = Client()

# use custom flight address
client = Client(
  flight_url="grpc://localhost:50055"
)

# use spice.ai cloud api
client = Client(
  api_key="API_KEY",
  flight_url="grpc+tls://flight.spiceai.io"
)

```