### PR TITLE
Conditionally run Spice.AI cloud tests only in a single job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
   test_pip_install:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
       matrix:
         python-version: ["3.11", "3.12"]
     name: Test with pip install ${{ matrix.python-version }}
@@ -33,6 +32,7 @@ jobs:
   pytest:
     runs-on: ${{ matrix.os }}
     strategy:
+      max-parallel: 1
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.11", "3.12"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
   test_pip_install:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 2
       matrix:
         python-version: ["3.11", "3.12"]
     name: Test with pip install ${{ matrix.python-version }}
@@ -94,6 +95,8 @@ jobs:
           cd spice_qs
           spice add spiceai/quickstart
           Start-Process -FilePath spice run
+          # time to initialize added dataset
+          Start-Sleep -Seconds 10
         shell: pwsh
 
       - name: Running tests
@@ -103,3 +106,11 @@ jobs:
           TEST_SPICE_CLOUD: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'}}
         run: |
           pytest -s
+
+      - name: Stop spice and check logs
+        working-directory: test_app
+        if: always()
+        run: |
+          sleep 10
+          killall spice
+          cat spice.log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12']
+        python-version: ["3.11", "3.12"]
     name: Test with pip install ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
       max-parallel: 1
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.11', '3.12']
+        python-version: ["3.11", "3.12"]
     name: Test on ${{ matrix.os }} with pytest ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
@@ -43,7 +43,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
       - name: Install requirements
         run: |
           pip install ".[test]"
@@ -109,8 +109,7 @@ jobs:
 
       - name: Stop spice and check logs
         working-directory: spice_qs
-        shell: bash
-        if: always()
+        if: matrix.os != 'windows-latest'
         run: |
           sleep 10
           killall spice

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,7 @@ jobs:
           pytest -s
 
       - name: Stop spice and check logs
-        working-directory: test_app
+        working-directory: spice_qs
         if: always()
         run: |
           sleep 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,7 @@ jobs:
 
       - name: Stop spice and check logs
         working-directory: spice_qs
+        shell: bash
         if: always()
         run: |
           sleep 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   test_pip_install:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 2
+      max-parallel: 1
       matrix:
         python-version: ["3.11", "3.12"]
     name: Test with pip install ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12']
+        python-version: ["3.11", "3.12"]
     name: Test with pip install ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.11', '3.12']
+        python-version: ["3.11", "3.12"]
     name: Test on ${{ matrix.os }} with pytest ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
       - name: Install requirements
         run: |
           pip install ".[test]"
@@ -99,5 +99,7 @@ jobs:
       - name: Running tests
         env:
           API_KEY: ${{ secrets.API_KEY }}
+          # run spice.ai cloud tests only on linux with single python version, to avoid concurrent requests
+          TEST_SPICE_CLOUD: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'}}
         run: |
           pytest -s

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ['3.11', '3.12']
     name: Test with pip install ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
       max-parallel: 1
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.11", "3.12"]
+        python-version: ['3.11', '3.12']
     name: Test on ${{ matrix.os }} with pytest ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
@@ -43,7 +43,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
+          cache: 'pip'
       - name: Install requirements
         run: |
           pip install ".[test]"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,13 @@
 
 import os
 import time
+import pytest
 from spicepy import Client
+
+# Skip cloud tests if TEST_SPICE_CLOUD is not set to true
+def skip_cloud():
+    skip_cloud = os.environ.get("TEST_SPICE_CLOUD") != "true"
+    return pytest.mark.skipif(skip_cloud, reason="Cloud tests disabled")
 
 
 def get_cloud_client():
@@ -16,6 +22,7 @@ def get_local_client():
     return Client(flight_url="grpc://localhost:50051")
 
 
+@skip_cloud()
 def test_flight_recent_blocks():
     client = get_cloud_client()
     data = client.query("SELECT * FROM eth.recent_blocks LIMIT 10")
@@ -23,6 +30,7 @@ def test_flight_recent_blocks():
     assert len(pandas_data) == 10
 
 
+@skip_cloud()
 def test_firecache_recent_blocks():
     client = get_cloud_client()
     data = client.fire_query("SELECT * FROM eth.recent_blocks LIMIT 10")
@@ -30,6 +38,7 @@ def test_firecache_recent_blocks():
     assert len(pandas_data) == 10
 
 
+@skip_cloud()
 def test_flight_streaming():
     client = get_cloud_client()
     query = """
@@ -58,6 +67,7 @@ FROM eth.blocks limit 2000
     assert num_batches > 1
 
 
+@skip_cloud()
 def test_flight_timeout():
     client = get_cloud_client()
     query = """SELECT block_number,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,10 +4,11 @@ import time
 import pytest
 from spicepy import Client
 
+
 # Skip cloud tests if TEST_SPICE_CLOUD is not set to true
 def skip_cloud():
-    skip_cloud = os.environ.get("TEST_SPICE_CLOUD") != "true"
-    return pytest.mark.skipif(skip_cloud, reason="Cloud tests disabled")
+    skip = os.environ.get("TEST_SPICE_CLOUD") != "true"
+    return pytest.mark.skipif(skip, reason="Cloud tests disabled")
 
 
 def get_cloud_client():


### PR DESCRIPTION
Runs spice.ai cloud tests only in single case (ubuntu latest, python 3.12) to reduce concurrent requests load.