### PR TITLE
feat: Add x-spice-user-agent

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
           spice add spiceai/quickstart
           spiced &> spice.log &
           # time to initialize added dataset
-          sleep 5
+          sleep 10
 
       - name: Init and start spice app (Windows)
         if: matrix.os == 'windows-latest'
@@ -93,7 +93,7 @@ jobs:
           spice add spiceai/quickstart
           Start-Process -FilePath spice run
           # time to initialize added dataset
-          Start-Sleep -Seconds 5
+          Start-Sleep -Seconds 10
         shell: pwsh
 
       - name: Running tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
   test_pip_install:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.11', '3.12']
     name: Test with pip install ${{ matrix.python-version }}
@@ -32,7 +33,7 @@ jobs:
   pytest:
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 1
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.11', '3.12']
@@ -48,24 +49,20 @@ jobs:
         run: |
           pip install ".[test]"
 
-      - name: install Spice
-        if: matrix.os != 'windows-latest'
+      - name: Install Spice (https://install.spiceai.org) (Linux)
+        if: matrix.os == 'ubuntu-latest'
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          function curl() {
-            if [ -z "$GH_TOKEN" ]
-            then
-              command curl -H "Accept: application/vnd.github.v3.raw" \
-                $@
-            else
-              command curl -H "Accept: application/vnd.github.v3.raw" \
-                -H "Authorization: token $GH_TOKEN" \
-                $@
-            fi
-          }
           curl https://install.spiceai.org | /bin/bash
           echo "$HOME/.spice/bin" >> $GITHUB_PATH
+          $HOME/.spice/bin/spice install
+      
+      - name: Install Spice (https://install.spiceai.org) (MacOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install spiceai/spiceai/spice
+          brew install spiceai/spiceai/spiced
 
       - name: install Spice (Windows)
         if: matrix.os == 'windows-latest'
@@ -84,9 +81,9 @@ jobs:
           spice init spice_qs
           cd spice_qs
           spice add spiceai/quickstart
-          spice run &> spice.log &
+          spiced &> spice.log &
           # time to initialize added dataset
-          sleep 10
+          sleep 5
 
       - name: Init and start spice app (Windows)
         if: matrix.os == 'windows-latest'
@@ -96,7 +93,7 @@ jobs:
           spice add spiceai/quickstart
           Start-Process -FilePath spice run
           # time to initialize added dataset
-          Start-Sleep -Seconds 10
+          Start-Sleep -Seconds 5
         shell: pwsh
 
       - name: Running tests
@@ -109,8 +106,7 @@ jobs:
 
       - name: Stop spice and check logs
         working-directory: spice_qs
-        if: matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-latest' && always()
         run: |
-          sleep 10
-          killall spice
+          killall spice || true
           cat spice.log

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 build
 dist
 spicepy.egg-info
+.env

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -5,11 +5,13 @@ import threading
 from typing import Dict, Union
 
 import certifi
+
+# pylint: disable=E0611
 from pyarrow._flight import (
     FlightCallOptions,
     FlightClient,
     Ticket,
-)  # pylint: disable=E0611
+)
 from ._http import HttpRequests
 from . import config
 

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -5,7 +5,11 @@ import threading
 from typing import Dict, Union
 
 import certifi
-from pyarrow._flight import FlightCallOptions, FlightClient, Ticket  # pylint: disable=E0611
+from pyarrow._flight import (
+    FlightCallOptions,
+    FlightClient,
+    Ticket,
+)  # pylint: disable=E0611
 from ._http import HttpRequests
 from . import config
 
@@ -56,17 +60,21 @@ class _SpiceFlight:
     def __init__(self, grpc: str, api_key: str, tls_root_certs):
         self._flight_client = flight.connect(grpc, tls_root_certs=tls_root_certs)
         self._api_key = api_key
-        self._flight_options = flight.FlightCallOptions()
+        self.headers = [("x-spice-user-agent", config.SPICE_USER_AGENT)]
+        self._flight_options = flight.FlightCallOptions(headers=self.headers)
         self._authenticate()
 
     def _authenticate(self):
         if self._api_key is not None:
-            self.headers = [self._flight_client.authenticate_basic_token("", self._api_key)]
+            self.headers = [
+                self._flight_client.authenticate_basic_token("", self._api_key),
+                ("x-spice-user-agent", config.SPICE_USER_AGENT),
+            ]
             self._flight_options = flight.FlightCallOptions(
                 headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS
             )
         else:
-            self.headers = []
+            self.headers = [("x-spice-user-agent", config.SPICE_USER_AGENT)]
             self._flight_options = flight.FlightCallOptions(
                 headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS
             )

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -59,24 +59,32 @@ class _Cert:
 
 
 class _SpiceFlight:
+    @staticmethod
+    def _user_agent():
+        # headers kwargs claim to support Tuple[str, str], but it's actually Tuple[bytes, bytes] :|
+        # Open issue in Arrow: https://github.com/apache/arrow/issues/35288
+        return (str.encode("x-spice-user-agent"), str.encode(config.SPICE_USER_AGENT))
+
     def __init__(self, grpc: str, api_key: str, tls_root_certs):
         self._flight_client = flight.connect(grpc, tls_root_certs=tls_root_certs)
         self._api_key = api_key
-        self.headers = [("x-spice-user-agent", config.SPICE_USER_AGENT)]
-        self._flight_options = flight.FlightCallOptions(headers=self.headers)
+        self.headers = [_SpiceFlight._user_agent()]
+        self._flight_options = flight.FlightCallOptions(
+            headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS
+        )
         self._authenticate()
 
     def _authenticate(self):
         if self._api_key is not None:
             self.headers = [
                 self._flight_client.authenticate_basic_token("", self._api_key),
-                ("x-spice-user-agent", config.SPICE_USER_AGENT),
+                _SpiceFlight._user_agent(),
             ]
             self._flight_options = flight.FlightCallOptions(
                 headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS
             )
         else:
-            self.headers = [("x-spice-user-agent", config.SPICE_USER_AGENT)]
+            self.headers = [_SpiceFlight._user_agent()]
             self._flight_options = flight.FlightCallOptions(
                 headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS
             )

--- a/spicepy/_http.py
+++ b/spicepy/_http.py
@@ -5,14 +5,19 @@ from requests import Response, Session
 from requests.adapters import HTTPAdapter, Retry
 
 from .error import SpiceAIError
+from .config import SPICE_USER_AGENT
 
 
-HttpMethod = Literal['POST', 'GET', 'PUT', 'HEAD', 'POST']
+HttpMethod = Literal["POST", "GET", "PUT", "HEAD", "POST"]
 
 
 class HttpRequests:
     def __init__(self, base_url: str, headers: Dict[str, str]) -> None:
         self.session = self._create_session(headers)
+
+        # set the x-spice-user-agent header
+        self.session.headers["X-Spice-User-Agent"] = SPICE_USER_AGENT
+
         self.base_url = base_url
 
     def send_request(

--- a/spicepy/config.py
+++ b/spicepy/config.py
@@ -1,8 +1,33 @@
 import os
+import pkg_resources
+import platform
 
 DEFAULT_FLIGHT_URL = os.environ.get("SPICE_FLIGHT_URL", "grpc+tls://flight.spiceai.io")
-DEFAULT_FIRECACHE_URL = os.environ.get("SPICE_FIRECACHE_URL", "grpc+tls://firecache.spiceai.io")
+DEFAULT_FIRECACHE_URL = os.environ.get(
+    "SPICE_FIRECACHE_URL", "grpc+tls://firecache.spiceai.io"
+)
 DEFAULT_HTTP_URL = os.environ.get("SPICE_HTTP_URL", "https://data.spiceai.io")
 
-DEFAULT_LOCAL_FLIGHT_URL = os.environ.get("SPICE_LOCAL_FLIGHT_URL", "grpc://localhost:50051")
-DEFAULT_LOCAL_HTTP_URL = os.environ.get("SPICE_LOCAL_HTTP_URL", "http://localhost:3000 ")
+DEFAULT_LOCAL_FLIGHT_URL = os.environ.get(
+    "SPICE_LOCAL_FLIGHT_URL", "grpc://localhost:50051"
+)
+DEFAULT_LOCAL_HTTP_URL = os.environ.get(
+    "SPICE_LOCAL_HTTP_URL", "http://localhost:3000 "
+)
+
+
+def get_user_agent():
+    package_version = pkg_resources.get_distribution("spicepy").version
+    system = platform.system()
+    release = platform.release()
+    arch = platform.architecture()[0]
+    if arch == "32bit":  # expect a shorthand x32 or x64
+        arch = "x32"
+    elif arch == "64bit":
+        arch = "x64"
+
+    system_info = "%s/%s %s" % (system, release, arch)
+    return "spicepy %s (%s)" % (package_version, system_info)
+
+
+SPICE_USER_AGENT = get_user_agent()

--- a/spicepy/config.py
+++ b/spicepy/config.py
@@ -21,6 +21,8 @@ def get_user_agent():
     system = platform.system()
     release = platform.release()
     arch = platform.machine()
+    if arch == "AMD64":
+        arch = "x86_64"
 
     system_info = f"{system}/{release} {arch}"
     return f"spicepy {package_version} {system_info}"

--- a/spicepy/config.py
+++ b/spicepy/config.py
@@ -20,11 +20,9 @@ def get_user_agent():
     package_version = version("spicepy")
     system = platform.system()
     release = platform.release()
-    arch = platform.architecture()[0]
-    if arch == "32bit":  # expect a shorthand x32 or x64
+    arch = platform.machine()
+    if arch == "i386":
         arch = "x86"
-    elif arch == "64bit":
-        arch = "x86_64"
 
     system_info = f"{system}/{release} {arch}"
     return f"spicepy {package_version} {system_info}"

--- a/spicepy/config.py
+++ b/spicepy/config.py
@@ -25,7 +25,7 @@ def get_user_agent():
         arch = "x86_64"
 
     system_info = f"{system}/{release} {arch}"
-    return f"spicepy {package_version} {system_info}"
+    return f"spicepy {package_version} ({system_info})"
 
 
 SPICE_USER_AGENT = get_user_agent()

--- a/spicepy/config.py
+++ b/spicepy/config.py
@@ -22,7 +22,7 @@ def get_user_agent():
     release = platform.release()
     arch = platform.architecture()[0]
     if arch == "32bit":  # expect a shorthand x32 or x64
-        arch = "x32"
+        arch = "x86_64"
     elif arch == "64bit":
         arch = "x64"
 

--- a/spicepy/config.py
+++ b/spicepy/config.py
@@ -1,6 +1,6 @@
 import os
-import pkg_resources
 import platform
+import pkg_resources
 
 DEFAULT_FLIGHT_URL = os.environ.get("SPICE_FLIGHT_URL", "grpc+tls://flight.spiceai.io")
 DEFAULT_FIRECACHE_URL = os.environ.get(
@@ -26,8 +26,8 @@ def get_user_agent():
     elif arch == "64bit":
         arch = "x64"
 
-    system_info = "%s/%s %s" % (system, release, arch)
-    return "spicepy %s (%s)" % (package_version, system_info)
+    system_info = f"{system}/{release} {arch}"
+    return f"spicepy {package_version} {system_info}"
 
 
 SPICE_USER_AGENT = get_user_agent()

--- a/spicepy/config.py
+++ b/spicepy/config.py
@@ -21,8 +21,6 @@ def get_user_agent():
     system = platform.system()
     release = platform.release()
     arch = platform.machine()
-    if arch == "i386":
-        arch = "x86"
 
     system_info = f"{system}/{release} {arch}"
     return f"spicepy {package_version} {system_info}"

--- a/spicepy/config.py
+++ b/spicepy/config.py
@@ -1,6 +1,6 @@
 import os
 import platform
-import pkg_resources
+from importlib.metadata import version
 
 DEFAULT_FLIGHT_URL = os.environ.get("SPICE_FLIGHT_URL", "grpc+tls://flight.spiceai.io")
 DEFAULT_FIRECACHE_URL = os.environ.get(
@@ -17,7 +17,7 @@ DEFAULT_LOCAL_HTTP_URL = os.environ.get(
 
 
 def get_user_agent():
-    package_version = pkg_resources.get_distribution("spicepy").version
+    package_version = version("spicepy")
     system = platform.system()
     release = platform.release()
     arch = platform.architecture()[0]

--- a/spicepy/config.py
+++ b/spicepy/config.py
@@ -22,9 +22,9 @@ def get_user_agent():
     release = platform.release()
     arch = platform.architecture()[0]
     if arch == "32bit":  # expect a shorthand x32 or x64
-        arch = "x86_64"
+        arch = "x86"
     elif arch == "64bit":
-        arch = "x64"
+        arch = "x86_64"
 
     system_info = f"{system}/{release} {arch}"
     return f"spicepy {package_version} {system_info}"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,6 @@
 import os
 import time
+import re
 import pytest
 from spicepy import Client
 from spicepy.config import SPICE_USER_AGENT
@@ -21,13 +22,10 @@ def get_local_client():
 
 
 def test_user_agent_is_populated():
-    expected_platforms = ["x86", "x86_64", "aarch64", "arm64"]
+    # use a regex to match the expected user agent string
+    matching_regex = r"spicepy \d+\.\d+\.\d+ \((Linux|Windows|macOS)/[\d\w\.\-\_]+ (x86_64|aarch64|i386|arm64)\)"
 
-    assert SPICE_USER_AGENT.split(" ")[0] == "spicepy"
-    assert SPICE_USER_AGENT.split(" ")[1] == "2.0.0"
-
-    arch = SPICE_USER_AGENT.split(" ")[3].replace(")", "")
-    assert arch in expected_platforms
+    assert re.match(matching_regex, SPICE_USER_AGENT)
 
 
 @skip_cloud()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,7 +23,7 @@ def get_local_client():
 
 def test_user_agent_is_populated():
     # use a regex to match the expected user agent string
-    matching_regex = r"spicepy \d+\.\d+\.\d+ \((Linux|Windows|macOS)/[\d\w\.\-\_]+ (x86_64|aarch64|i386|arm64)\)"
+    matching_regex = r"spicepy \d+\.\d+\.\d+ \((Linux|Windows|Darwin)/[\d\w\.\-\_]+ (x86_64|aarch64|i386|arm64)\)"
 
     assert re.match(matching_regex, SPICE_USER_AGENT)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,11 +21,13 @@ def get_local_client():
 
 
 def test_user_agent_is_populated():
-    expected_platforms = ["x86", "x86_64"]
+    expected_platforms = ["x86", "x86_64", "aarch64"]
 
     assert SPICE_USER_AGENT.split(" ")[0] == "spicepy"
     assert SPICE_USER_AGENT.split(" ")[1] == "2.0.0"
-    assert SPICE_USER_AGENT.split(" ")[3][:3] in expected_platforms
+
+    arch = SPICE_USER_AGENT.split(" ")[3].replace(")", "")
+    assert arch in expected_platforms
 
 
 @skip_cloud()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,8 @@
-
 import os
 import time
 import pytest
 from spicepy import Client
+from spicepy.config import SPICE_USER_AGENT
 
 
 # Skip cloud tests if TEST_SPICE_CLOUD is not set to true
@@ -13,14 +13,19 @@ def skip_cloud():
 
 def get_cloud_client():
     api_key = os.environ["API_KEY"]
-    return Client(
-        api_key=api_key,
-        flight_url="grpc+tls://flight.spiceai.io"
-    )
+    return Client(api_key=api_key, flight_url="grpc+tls://flight.spiceai.io")
 
 
 def get_local_client():
     return Client(flight_url="grpc://localhost:50051")
+
+
+def test_user_agent_is_populated():
+    EXPECTED_PLATFORMS = ["x64", "x32"]
+
+    assert SPICE_USER_AGENT.split(" ")[0] == "spicepy"
+    assert SPICE_USER_AGENT.split(" ")[1] == "2.0.0"
+    assert SPICE_USER_AGENT.split(" ")[3][:3] in EXPECTED_PLATFORMS
 
 
 @skip_cloud()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,7 +21,7 @@ def get_local_client():
 
 
 def test_user_agent_is_populated():
-    expected_platforms = ["x86", "x86_64", "aarch64", "arm64", "AMD64"]
+    expected_platforms = ["x86", "x86_64", "aarch64", "arm64"]
 
     assert SPICE_USER_AGENT.split(" ")[0] == "spicepy"
     assert SPICE_USER_AGENT.split(" ")[1] == "2.0.0"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,7 +21,7 @@ def get_local_client():
 
 
 def test_user_agent_is_populated():
-    expected_platforms = ["x64", "x86_64"]
+    expected_platforms = ["x86", "x86_64"]
 
     assert SPICE_USER_AGENT.split(" ")[0] == "spicepy"
     assert SPICE_USER_AGENT.split(" ")[1] == "2.0.0"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,7 +21,7 @@ def get_local_client():
 
 
 def test_user_agent_is_populated():
-    expected_platforms = ["x64", "x32"]
+    expected_platforms = ["x64", "x86_64"]
 
     assert SPICE_USER_AGENT.split(" ")[0] == "spicepy"
     assert SPICE_USER_AGENT.split(" ")[1] == "2.0.0"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,11 +21,11 @@ def get_local_client():
 
 
 def test_user_agent_is_populated():
-    EXPECTED_PLATFORMS = ["x64", "x32"]
+    expected_platforms = ["x64", "x32"]
 
     assert SPICE_USER_AGENT.split(" ")[0] == "spicepy"
     assert SPICE_USER_AGENT.split(" ")[1] == "2.0.0"
-    assert SPICE_USER_AGENT.split(" ")[3][:3] in EXPECTED_PLATFORMS
+    assert SPICE_USER_AGENT.split(" ")[3][:3] in expected_platforms
 
 
 @skip_cloud()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,7 +21,7 @@ def get_local_client():
 
 
 def test_user_agent_is_populated():
-    expected_platforms = ["x86", "x86_64", "aarch64", "arm64"]
+    expected_platforms = ["x86", "x86_64", "aarch64", "arm64", "AMD64"]
 
     assert SPICE_USER_AGENT.split(" ")[0] == "spicepy"
     assert SPICE_USER_AGENT.split(" ")[1] == "2.0.0"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,7 +21,7 @@ def get_local_client():
 
 
 def test_user_agent_is_populated():
-    expected_platforms = ["x86", "x86_64", "aarch64"]
+    expected_platforms = ["x86", "x86_64", "aarch64", "arm64"]
 
     assert SPICE_USER_AGENT.split(" ")[0] == "spicepy"
     assert SPICE_USER_AGENT.split(" ")[1] == "2.0.0"


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds the `x-spice-user-agent` header to Flight and HTTP calls

Matches the same header format as [spice.js](https://github.com/spiceai/spice.js/pull/186), like `spicepy 2.0.0 (Linux/6.9.3-76060903-generic 64bit)`

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #108 