### PR TITLE
Handle empty api_key

### DIFF
--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -219,7 +219,7 @@ class _SpiceFlight:
         self._authenticate()
 
     def _authenticate(self):
-        if self._api_key is not None:
+        if self._api_key:
             self.headers = [
                 self._flight_client.authenticate_basic_token("", self._api_key),
                 _SpiceFlight._user_agent(),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -908,6 +908,35 @@ class TestSpiceFlight:
         assert len(flight_instance.headers) == 1
         assert flight_instance.headers[0][0] == b"user-agent"
 
+    @patch("spicepy._client.flight")
+    def test_spice_flight_authenticate_with_empty_string_api_key(
+        self,
+        mock_flight: MagicMock,
+    ) -> None:
+        """Test _SpiceFlight authentication with empty string API key.
+
+        Empty string API key should be treated the same as None - no authentication
+        should be attempted. This prevents gRPC errors like 'Metadata keys cannot
+        be zero length' that occur when authenticate_basic_token is called with
+        empty credentials.
+        """
+        from spicepy._client import _SpiceFlight
+
+        mock_client = MagicMock()
+        mock_flight.connect.return_value = mock_client
+
+        flight_instance = _SpiceFlight(
+            grpc="grpc://localhost:50051",
+            api_key="",
+            tls_root_certs=b"cert",
+        )
+
+        # authenticate_basic_token should not be called when api_key is empty string
+        mock_client.authenticate_basic_token.assert_not_called()
+        # Headers should only contain user-agent
+        assert len(flight_instance.headers) == 1
+        assert flight_instance.headers[0][0] == b"user-agent"
+
 
 class TestArrowFlightCallThread:
     """Test _ArrowFlightCallThread class."""


### PR DESCRIPTION
## 🗣 Description

This pull request improves authentication logic in the `_SpiceFlight` client to handle empty API keys more robustly and adds corresponding test coverage. The main focus is to ensure that an empty string for `api_key` is treated the same as `None`, preventing unwanted authentication attempts and related gRPC errors.

Authentication logic improvements:

* Updated the `_authenticate` method in `_SpiceFlight` (in `spicepy/_client.py`) to treat an empty string `api_key` as unauthenticated, preventing calls to `authenticate_basic_token` with empty credentials.

Test coverage enhancements:

* Added a new test (`test_spice_flight_authenticate_with_empty_string_api_key`) in `tests/test_client.py` to verify that no authentication is attempted and only the user-agent header is set when `api_key` is an empty string.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
