### PR TITLE
chore(deps): upgrade all dependencies to latest versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,41 +4,41 @@
 version: 2
 updates:
   # Python dependencies (pip)
-  - package-ecosystem: "pip"
-    directory: "/"
+  - package-ecosystem: 'pip'
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "America/Los_Angeles"
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'America/Los_Angeles'
     open-pull-requests-limit: 10
     labels:
-      - "dependencies"
-      - "python"
+      - 'dependencies'
+      - 'python'
     commit-message:
-      prefix: "chore(deps)"
+      prefix: 'chore(deps)'
     groups:
       # Group all Python dependency updates into a single PR
       python-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   # GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "America/Los_Angeles"
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'America/Los_Angeles'
     open-pull-requests-limit: 5
     labels:
-      - "dependencies"
-      - "github-actions"
+      - 'dependencies'
+      - 'github-actions'
     commit-message:
-      prefix: "chore(deps)"
+      prefix: 'chore(deps)'
     groups:
       # Group GitHub Actions updates
       actions:
         patterns:
-          - "*"
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,24 +18,10 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     groups:
-      # Group minor/patch updates for dev dependencies
-      dev-dependencies:
+      # Group all Python dependency updates into a single PR
+      python-dependencies:
         patterns:
-          - "pytest*"
-          - "pylint"
-          - "flake8"
-          - "ruff"
-          - "mypy"
-          - "bandit"
-          - "types-*"
-          - "*-stubs"
-        update-types:
-          - "minor"
-          - "patch"
-      # Group ADBC driver updates
-      adbc:
-        patterns:
-          - "adbc-driver-*"
+          - "*"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     name: Build on ${{ matrix.os }} with Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -84,6 +84,27 @@ jobs:
         run: |
           mypy spicepy --ignore-missing-imports
 
+  lint-black:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12', '3.13', '3.14']
+    name: Lint with black (Python ${{ matrix.python-version }})
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - name: Install requirements
+        run: |
+          pip install ".[test]"
+      - name: Check formatting with black
+        run: |
+          black --check spicepy tests
+
   security-check:
     runs-on: ubuntu-latest
     name: Security scan with bandit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     name: Lint with ruff (Python ${{ matrix.python-version }})
     steps:
       - uses: actions/checkout@v6
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     name: Lint with pylint (Python ${{ matrix.python-version }})
     steps:
       - uses: actions/checkout@v6
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     name: Type check with mypy (Python ${{ matrix.python-version }})
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Install requirements
         run: |
           pip install ".[test]"
-      - name: Check formatting with ruff
-        run: |
-          ruff format --check spicepy tests
       - name: Lint with ruff
         run: |
           ruff check spicepy tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,15 +125,17 @@ jobs:
           spice init spice_qs
           cd spice_qs
           spice add spiceai/quickstart
-          Start-Process -FilePath spice run
+          Start-Process -FilePath spice -ArgumentList 'run' -RedirectStandardOutput spice.out.log -RedirectStandardError spice.err.log
           # Wait for runtime to be ready (poll /v1/ready endpoint)
-          $timeout = 60
+          $timeout = 120
           $elapsed = 0
+          $ready = $false
           while ($elapsed -lt $timeout) {
             try {
               $response = Invoke-WebRequest -Uri "http://localhost:8090/v1/ready" -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop
               if ($response.StatusCode -eq 200) {
                 Write-Host "Spice runtime is ready"
+                $ready = $true
                 break
               }
             } catch {
@@ -141,6 +143,13 @@ jobs:
             }
             Start-Sleep -Seconds 1
             $elapsed++
+          }
+          if (-not $ready) {
+            Write-Host "=== spice stdout log ==="
+            if (Test-Path spice.out.log) { Get-Content spice.out.log }
+            Write-Host "=== spice stderr log ==="
+            if (Test-Path spice.err.log) { Get-Content spice.err.log }
+            throw "Spice runtime did not become ready within $timeout seconds"
           }
         shell: pwsh
 
@@ -158,6 +167,18 @@ jobs:
         run: |
           killall spice || true
           cat spice.log
+
+      - name: Stop spice and check logs (Windows)
+        working-directory: spice_qs
+        if: matrix.os == 'windows-latest' && always()
+        run: |
+          Get-Process -Name spice -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+          Get-Process -Name spiced -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+          Write-Host "=== spice stdout log ==="
+          if (Test-Path spice.out.log) { Get-Content spice.out.log }
+          Write-Host "=== spice stderr log ==="
+          if (Test-Path spice.err.log) { Get-Content spice.err.log }
+        shell: pwsh
 
   pytest-cloud:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     name: Test pip install (Python ${{ matrix.python-version }})
     steps:
       - uses: actions/checkout@v6
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     name: Unit tests on ${{ matrix.os }} (Python ${{ matrix.python-version }})
     steps:
       - uses: actions/checkout@v6
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     name: Integration tests on ${{ matrix.os }} (Python ${{ matrix.python-version }})
     steps:
       - uses: actions/checkout@v6
@@ -188,7 +188,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     name: Test coverage (Python ${{ matrix.python-version }})
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
       # guest).
       - name: Set up WSL (Windows)
         if: matrix.os == 'windows-latest'
-        uses: Vampire/setup-wsl@v6
+        uses: Vampire/setup-wsl@887f39deb6c0976365e546926fe66f41b77d65ff # v6.1.0
         with:
           distribution: Ubuntu-24.04
           additional-packages: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,6 +122,7 @@ jobs:
       - name: Init and start spice app (Windows)
         if: matrix.os == 'windows-latest'
         run: |
+          spice install
           spice init spice_qs
           cd spice_qs
           spice add spiceai/quickstart

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,13 @@ jobs:
           spice init spice_qs
           cd spice_qs
           spice add spiceai/quickstart
-          Start-Process -FilePath spice -ArgumentList 'run' -RedirectStandardOutput spice.out.log -RedirectStandardError spice.err.log
+          # Use spiced directly; `spice run` on Windows has a bug where it
+          # reinstalls the runtime and then fails to locate it.
+          $spiced = Join-Path $HOME ".spice\bin\spiced.exe"
+          if (-not (Test-Path $spiced)) {
+            throw "spiced not found at $spiced after `spice install`"
+          }
+          Start-Process -FilePath $spiced -RedirectStandardOutput spice.out.log -RedirectStandardError spice.err.log
           # Wait for runtime to be ready (poll /v1/ready endpoint)
           $timeout = 120
           $elapsed = 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,16 +91,26 @@ jobs:
           brew install spiceai/spiceai/spice
           brew install spiceai/spiceai/spiced
 
-      - name: install Spice (Windows)
+      # Spice on Windows is only supported via WSL. Set up Ubuntu under WSL
+      # and install Spice there; the tests on the Windows host then talk to
+      # the runtime over localhost (WSL2 forwards localhost between host and
+      # guest).
+      - name: Set up WSL (Windows)
         if: matrix.os == 'windows-latest'
-        run: |
-          curl -L "https://install.spiceai.org/Install.ps1" -o Install.ps1 && PowerShell -ExecutionPolicy Bypass -File ./Install.ps1
+        uses: Vampire/setup-wsl@v6
+        with:
+          distribution: Ubuntu-24.04
+          additional-packages: |
+            curl
+            ca-certificates
 
-      - name: add Spice bin to PATH (Windows)
+      - name: install Spice in WSL (Windows)
         if: matrix.os == 'windows-latest'
+        shell: wsl-bash {0}
         run: |
-          Add-Content $env:GITHUB_PATH (Join-Path $HOME ".spice\bin")
-        shell: pwsh
+          curl https://install.spiceai.org | /bin/bash
+          echo "$HOME/.spice/bin" >> $GITHUB_PATH
+          $HOME/.spice/bin/spice install
 
       - name: Init and start spice app
         if: matrix.os != 'windows-latest'
@@ -121,44 +131,25 @@ jobs:
 
       - name: Init and start spice app (Windows)
         if: matrix.os == 'windows-latest'
+        shell: wsl-bash {0}
         run: |
-          spice install
           spice init spice_qs
           cd spice_qs
           spice add spiceai/quickstart
-          # Use spiced directly; `spice run` on Windows has a bug where it
-          # reinstalls the runtime and then fails to locate it.
-          $spiced = Join-Path $HOME ".spice\bin\spiced.exe"
-          if (-not (Test-Path $spiced)) {
-            throw "spiced not found at $spiced after `spice install`"
-          }
-          Start-Process -FilePath $spiced -RedirectStandardOutput spice.out.log -RedirectStandardError spice.err.log
+          nohup spiced > spice.log 2>&1 &
           # Wait for runtime to be ready (poll /v1/ready endpoint)
-          $timeout = 120
-          $elapsed = 0
-          $ready = $false
-          while ($elapsed -lt $timeout) {
-            try {
-              $response = Invoke-WebRequest -Uri "http://localhost:8090/v1/ready" -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop
-              if ($response.StatusCode -eq 200) {
-                Write-Host "Spice runtime is ready"
-                $ready = $true
-                break
-              }
-            } catch {
-              Write-Host "Waiting for Spice runtime to be ready... ($elapsed/$timeout)"
-            }
-            Start-Sleep -Seconds 1
-            $elapsed++
-          }
-          if (-not $ready) {
-            Write-Host "=== spice stdout log ==="
-            if (Test-Path spice.out.log) { Get-Content spice.out.log }
-            Write-Host "=== spice stderr log ==="
-            if (Test-Path spice.err.log) { Get-Content spice.err.log }
-            throw "Spice runtime did not become ready within $timeout seconds"
-          }
-        shell: pwsh
+          for i in $(seq 1 120); do
+            if curl -s http://localhost:8090/v1/ready > /dev/null 2>&1; then
+              echo "Spice runtime is ready"
+              exit 0
+            fi
+            echo "Waiting for Spice runtime to be ready... ($i/120)"
+            sleep 1
+          done
+          echo "=== spice log ==="
+          cat spice.log || true
+          echo "Spice runtime did not become ready within 120 seconds"
+          exit 1
 
       - name: Running tests
         env:
@@ -176,16 +167,12 @@ jobs:
           cat spice.log
 
       - name: Stop spice and check logs (Windows)
-        working-directory: spice_qs
         if: matrix.os == 'windows-latest' && always()
+        shell: wsl-bash {0}
         run: |
-          Get-Process -Name spice -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
-          Get-Process -Name spiced -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
-          Write-Host "=== spice stdout log ==="
-          if (Test-Path spice.out.log) { Get-Content spice.out.log }
-          Write-Host "=== spice stderr log ==="
-          if (Test-Path spice.err.log) { Get-Content spice.err.log }
-        shell: pwsh
+          pkill -f spiced || true
+          echo "=== spice log ==="
+          cat spice_qs/spice.log || true
 
   pytest-cloud:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,6 @@ jobs:
         shell: wsl-bash {0}
         run: |
           curl https://install.spiceai.org | /bin/bash
-          echo "$HOME/.spice/bin" >> $GITHUB_PATH
           $HOME/.spice/bin/spice install
 
       - name: Init and start spice app
@@ -133,6 +132,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: wsl-bash {0}
         run: |
+          export PATH="$HOME/.spice/bin:$PATH"
           spice init spice_qs
           cd spice_qs
           spice add spiceai/quickstart

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=59.0", "wheel"]
+requires = ["setuptools>=82.0.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -10,10 +10,10 @@ readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"
 dependencies = [
-    "pyarrow>=18.0.0",
-    "pandas>=2.2.3",
-    "certifi>=2024.8.30",
-    "requests>=2.32.3",
+    "pyarrow>=23.0.1",
+    "pandas>=3.0.2",
+    "certifi>=2026.2.25",
+    "requests>=2.33.1",
 ]
 authors = [
     {name = "Spice AI, Inc.", email = "webmaster@spice.ai"}
@@ -40,26 +40,26 @@ Issues = "https://github.com/spiceai/spicepy/issues"
 
 [project.optional-dependencies]
 test = [
-    "pylint>=3.3.1",
-    "flake8>=7.1.1",
-    "ruff>=0.4.0",
-    "mypy>=1.10.0",
-    "pytest>=8.3.3",
-    "pytest-cov>=5.0.0",
-    "pytest-xdist>=3.5.0",
-    "pytest-timeout>=2.3.1",
-    "pytest_httpserver==1.1.3",
-    "types-requests>=2.31.0",
-    "pandas-stubs>=2.0.0",
-    "bandit>=1.7.8",
-    "pandas>=2.0.0",
-    "pyarrow>=18.0.0",
-    "adbc-driver-flightsql>=1.3.0",
-    "adbc-driver-manager>=1.3.0",
+    "pylint>=4.0.5",
+    "flake8>=7.3.0",
+    "ruff>=0.15.10",
+    "mypy>=1.20.0",
+    "pytest>=9.0.3",
+    "pytest-cov>=7.1.0",
+    "pytest-xdist>=3.8.0",
+    "pytest-timeout>=2.4.0",
+    "pytest_httpserver==1.1.5",
+    "types-requests>=2.33.0",
+    "pandas-stubs>=3.0.0",
+    "bandit>=1.9.4",
+    "pandas>=3.0.2",
+    "pyarrow>=23.0.1",
+    "adbc-driver-flightsql>=1.11.0",
+    "adbc-driver-manager>=1.11.0",
 ]
 params = [
-    "adbc-driver-flightsql>=1.3.0",
-    "adbc-driver-manager>=1.3.0",
+    "adbc-driver-flightsql>=1.11.0",
+    "adbc-driver-manager>=1.11.0",
 ]
 
 # ============== Tool Configuration ==============
@@ -250,5 +250,5 @@ skips = ["B101"]  # assert_used
 
 [dependency-groups]
 dev = [
-    "build>=1.3.0",
+    "build>=1.4.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Spice.ai client library for Python"
 readme = "README.md"
 license = {text = "Apache-2.0"}
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "pyarrow>=23.0.1",
     "pandas>=3.0.2",
@@ -22,7 +22,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -65,7 +64,7 @@ params = [
 # ============== Tool Configuration ==============
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 warn_redundant_casts = true
@@ -99,7 +98,7 @@ module = [
 ignore_missing_imports = true
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py311"
 line-length = 120
 exclude = [
     ".git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ test = [
     "pytest_httpserver==1.1.5",
     "types-requests>=2.33.0",
     "pandas-stubs>=3.0.0",
+    "black>=26.3.1",
     "bandit>=1.9.4",
     "pandas>=3.0.2",
     "pyarrow>=23.0.1",
@@ -189,7 +190,7 @@ ignore = [
 [tool.ruff.lint.isort]
 known-first-party = ["spicepy"]
 force-single-line = false
-lines-after-imports = 2
+force-sort-within-sections = true
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyarrow>=17.0.0
-pandas>=2.2.3
-certifi>=2024.8.30
-requests>=2.32.3
+pyarrow>=23.0.1
+pandas>=3.0.2
+certifi>=2026.2.25
+requests>=2.33.1

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,8 @@ def setup_package():
         extras_require={
             "test": parse_requirements("test.requirements.txt"),
             "params": [
-                "adbc-driver-flightsql>=1.0.0",
-                "adbc-driver-manager>=1.0.0",
+                "adbc-driver-flightsql>=1.11.0",
+                "adbc-driver-manager>=1.11.0",
             ],
         },
         python_requires=">=3.9",

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,6 @@ def setup_package():
             "Development Status :: 4 - Beta",
             "Intended Audience :: Developers",
             "License :: OSI Approved :: Apache Software License",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",
             "Topic :: Software Development :: Libraries",
@@ -57,7 +55,7 @@ def setup_package():
                 "adbc-driver-manager>=1.11.0",
             ],
         },
-        python_requires=">=3.9",
+        python_requires=">=3.11",
         platforms=["Any"],
     )
 

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -3,7 +3,7 @@ import os
 import platform
 import threading
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any
 
 import certifi
 import pyarrow as pa
@@ -54,8 +54,8 @@ class _ADBCClient:
     def __init__(
         self,
         uri: str,
-        api_key: Optional[str] = None,
-        user_agent: Optional[str] = None,
+        api_key: str | None = None,
+        user_agent: str | None = None,
     ):
         if not ADBC_AVAILABLE:
             raise ImportError(
@@ -120,7 +120,7 @@ class _ADBCClient:
 
         # Create parameter arrays (each with a single row)
         param_arrays = []
-        for value, arrow_type in zip(param_values, param_types):
+        for value, arrow_type in zip(param_values, param_types, strict=True):
             param_arrays.append(pa.array([value], type=arrow_type))
 
         # Create parameter schema with positional field names ($1, $2, etc.)
@@ -268,11 +268,11 @@ class Client:
     # pylint: disable=R0917
     def __init__(
         self,
-        api_key: Optional[str] = None,
+        api_key: str | None = None,
         flight_url: str = config.DEFAULT_LOCAL_FLIGHT_URL,
         http_url: str = config.DEFAULT_HTTP_URL,
-        tls_root_cert: Union[str, Path, None] = None,
-        user_agent: Optional[str] = None,
+        tls_root_cert: str | Path | None = None,
+        user_agent: str | None = None,
     ):  # pylint: disable=R0913
         tls_root_certs = _Cert(tls_root_cert).tls_root_certs
         self._flight = _SpiceFlight(flight_url, api_key or "", tls_root_certs, user_agent)
@@ -280,7 +280,7 @@ class Client:
         self.api_key = api_key
         self._flight_url = flight_url
         self._user_agent = user_agent
-        self._adbc_client: Optional[_ADBCClient] = None
+        self._adbc_client: _ADBCClient | None = None
         self.http = HttpRequests(http_url, self._headers(user_agent))
 
     def _headers(self, user_agent=None) -> dict[str, str]:
@@ -373,7 +373,7 @@ class Client:
         adbc = self._ensure_adbc_client()
         return adbc.query_with_params(sql, params)
 
-    def refresh_dataset(self, dataset: str, refresh_opts: Optional[RefreshOpts] = None) -> Any:
+    def refresh_dataset(self, dataset: str, refresh_opts: RefreshOpts | None = None) -> Any:
         response = self.http.send_request(
             "POST",
             f"/v1/datasets/{dataset}/acceleration/refresh",

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -1,8 +1,8 @@
 import json
 import os
+from pathlib import Path
 import platform
 import threading
-from pathlib import Path
 from typing import Any
 
 import certifi
@@ -21,7 +21,10 @@ from .params import infer_arrow_type
 
 
 def is_macos_arm64() -> bool:
-    return platform.platform().lower().startswith("macos") and platform.machine() == "arm64"
+    return (
+        platform.platform().lower().startswith("macos")
+        and platform.machine() == "arm64"
+    )
 
 
 try:
@@ -85,7 +88,9 @@ class _ADBCClient:
         # Add authentication if API key provided
         if self._api_key:
             db_kwargs[adbc_driver_manager.DatabaseOptions.USERNAME.value] = ""
-            db_kwargs[adbc_driver_manager.DatabaseOptions.PASSWORD.value] = self._api_key
+            db_kwargs[adbc_driver_manager.DatabaseOptions.PASSWORD.value] = (
+                self._api_key
+            )
 
         # Create low-level database and connection (avoids dbapi autocommit warning)
         self._db = adbc_driver_flightsql.connect(self._uri, db_kwargs=db_kwargs)
@@ -110,7 +115,11 @@ class _ADBCClient:
 
         for param in params:
             # Check if param is a tuple of (value, arrow_type)
-            if isinstance(param, tuple) and len(param) == 2 and isinstance(param[1], pa.DataType):
+            if (
+                isinstance(param, tuple)
+                and len(param) == 2
+                and isinstance(param[1], pa.DataType)
+            ):
                 value, arrow_type = param
                 param_values.append(value)
                 param_types.append(arrow_type)
@@ -124,7 +133,9 @@ class _ADBCClient:
             param_arrays.append(pa.array([value], type=arrow_type))
 
         # Create parameter schema with positional field names ($1, $2, etc.)
-        param_fields = [pa.field(f"${i + 1}", param_types[i]) for i in range(len(params))]
+        param_fields = [
+            pa.field(f"${i + 1}", param_types[i]) for i in range(len(params))
+        ]
         param_schema = pa.schema(param_fields)
 
         return pa.record_batch(param_arrays, schema=param_schema)
@@ -189,7 +200,11 @@ class _Cert:
         tls_root_cert,
     ):
         if tls_root_cert is not None:
-            tls_root_cert = tls_root_cert if isinstance(tls_root_cert, Path) else Path(tls_root_cert)
+            tls_root_cert = (
+                tls_root_cert
+                if isinstance(tls_root_cert, Path)
+                else Path(tls_root_cert)
+            )
         else:
             tls_root_cert = Path(certifi.where())
 
@@ -208,14 +223,19 @@ class _SpiceFlight:
 
         # Prepend the custom user agent (if provided) to the default user agent
         if custom_user_agent:
-            return (str.encode("user-agent"), str.encode(f"{custom_user_agent} {config.SPICE_USER_AGENT}"))
+            return (
+                str.encode("user-agent"),
+                str.encode(f"{custom_user_agent} {config.SPICE_USER_AGENT}"),
+            )
         return (str.encode("user-agent"), str.encode(config.SPICE_USER_AGENT))
 
     def __init__(self, grpc: str, api_key: str, tls_root_certs, user_agent=None):
         self._flight_client = flight.connect(grpc, tls_root_certs=tls_root_certs)
         self._api_key = api_key
         self.headers = [_SpiceFlight._user_agent(user_agent)]
-        self._flight_options = flight.FlightCallOptions(headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS)
+        self._flight_options = flight.FlightCallOptions(
+            headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS
+        )
         self._authenticate()
 
     def _authenticate(self):
@@ -224,10 +244,14 @@ class _SpiceFlight:
                 self._flight_client.authenticate_basic_token("", self._api_key),
                 _SpiceFlight._user_agent(),
             ]
-            self._flight_options = flight.FlightCallOptions(headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS)
+            self._flight_options = flight.FlightCallOptions(
+                headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS
+            )
         else:
             self.headers = [_SpiceFlight._user_agent()]
-            self._flight_options = flight.FlightCallOptions(headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS)
+            self._flight_options = flight.FlightCallOptions(
+                headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS
+            )
 
     def query(self, query: str, **kwargs) -> flight.FlightStreamReader:
         timeout = kwargs.get("timeout")
@@ -235,19 +259,27 @@ class _SpiceFlight:
         if timeout is not None:
             if not isinstance(timeout, int) or timeout <= 0:
                 raise ValueError("Timeout must be a positive integer")
-            self._flight_options = flight.FlightCallOptions(headers=self.headers, timeout=timeout)
+            self._flight_options = flight.FlightCallOptions(
+                headers=self.headers, timeout=timeout
+            )
 
         flight_info = self._flight_client.get_flight_info(
             flight.FlightDescriptor.for_command(query), self._flight_options
         )
 
         try:
-            reader = self._threaded_flight_do_get(ticket=flight_info.endpoints[0].ticket)
+            reader = self._threaded_flight_do_get(
+                ticket=flight_info.endpoints[0].ticket
+            )
         except flight.FlightUnauthenticatedError:
             self._authenticate()
-            reader = self._threaded_flight_do_get(ticket=flight_info.endpoints[0].ticket)
+            reader = self._threaded_flight_do_get(
+                ticket=flight_info.endpoints[0].ticket
+            )
         except flight.FlightTimedOutError as exc:
-            raise TimeoutError(f"Query timed out and was canceled after {timeout} seconds.") from exc
+            raise TimeoutError(
+                f"Query timed out and was canceled after {timeout} seconds."
+            ) from exc
 
         return reader
 
@@ -275,7 +307,9 @@ class Client:
         user_agent: str | None = None,
     ):  # pylint: disable=R0913
         tls_root_certs = _Cert(tls_root_cert).tls_root_certs
-        self._flight = _SpiceFlight(flight_url, api_key or "", tls_root_certs, user_agent)
+        self._flight = _SpiceFlight(
+            flight_url, api_key or "", tls_root_certs, user_agent
+        )
 
         self.api_key = api_key
         self._flight_url = flight_url
@@ -369,15 +403,23 @@ class Client:
             ValueError: If params is None
         """
         if params is None:
-            raise ValueError("params must be a list, not None. Use [] for queries without parameters.")
+            raise ValueError(
+                "params must be a list, not None. Use [] for queries without parameters."
+            )
         adbc = self._ensure_adbc_client()
         return adbc.query_with_params(sql, params)
 
-    def refresh_dataset(self, dataset: str, refresh_opts: RefreshOpts | None = None) -> Any:
+    def refresh_dataset(
+        self, dataset: str, refresh_opts: RefreshOpts | None = None
+    ) -> Any:
         response = self.http.send_request(
             "POST",
             f"/v1/datasets/{dataset}/acceleration/refresh",
-            body=(json.dumps(refresh_opts.to_dict()) if refresh_opts is not None else json.dumps({})),
+            body=(
+                json.dumps(refresh_opts.to_dict())
+                if refresh_opts is not None
+                else json.dumps({})
+            ),
             headers={"Content-Type": "application/json"},
         )
 

--- a/spicepy/_http.py
+++ b/spicepy/_http.py
@@ -1,6 +1,7 @@
 import datetime
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Callable, Literal, Optional
+from typing import Any, Literal
 
 from requests import Response, Session
 from requests.adapters import HTTPAdapter, Retry
@@ -11,9 +12,9 @@ from .error import SpiceAIError
 
 @dataclass
 class RefreshOpts:
-    refresh_sql: Optional[str] = None
-    refresh_mode: Optional[str] = None
-    refresh_jitter_max: Optional[str] = None
+    refresh_sql: str | None = None
+    refresh_mode: str | None = None
+    refresh_jitter_max: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -42,9 +43,9 @@ class HttpRequests:
         self,
         method: HttpMethod,
         path: str,
-        param: Optional[dict[str, Any]] = None,
-        headers: Optional[dict[str, Any]] = None,
-        body: Optional[str] = None,
+        param: dict[str, Any] | None = None,
+        headers: dict[str, Any] | None = None,
+        body: str | None = None,
     ) -> Any:
         if headers is None:
             headers = {}

--- a/spicepy/_http.py
+++ b/spicepy/_http.py
@@ -1,6 +1,6 @@
-import datetime
 from collections.abc import Callable
 from dataclasses import dataclass
+import datetime
 from typing import Any, Literal
 
 from requests import Response, Session

--- a/spicepy/config.py
+++ b/spicepy/config.py
@@ -1,12 +1,13 @@
+from importlib.metadata import version
 import os
 import platform
-from importlib.metadata import version
-
 
 DEFAULT_FLIGHT_URL = os.environ.get("SPICE_FLIGHT_URL", "grpc+tls://flight.spiceai.io")
 DEFAULT_HTTP_URL = os.environ.get("SPICE_HTTP_URL", "https://data.spiceai.io")
 
-DEFAULT_LOCAL_FLIGHT_URL = os.environ.get("SPICE_LOCAL_FLIGHT_URL", "grpc://localhost:50051")
+DEFAULT_LOCAL_FLIGHT_URL = os.environ.get(
+    "SPICE_LOCAL_FLIGHT_URL", "grpc://localhost:50051"
+)
 DEFAULT_LOCAL_HTTP_URL = os.environ.get("SPICE_LOCAL_HTTP_URL", "http://localhost:8090")
 
 
@@ -19,7 +20,9 @@ DEFAULT_LOCAL_HTTP_URL = os.environ.get("SPICE_LOCAL_HTTP_URL", "http://localhos
 #   Default is the system information of the current system, e.g. `Linux/5.4.0-1043-aws x86_64`.
 ###
 def get_user_agent(
-    client_name: str | None = None, client_version: str | None = None, client_system: str | None = None
+    client_name: str | None = None,
+    client_version: str | None = None,
+    client_system: str | None = None,
 ) -> str:
     package_version = version("spicepy") if client_version is None else client_version
     system = platform.system()
@@ -28,7 +31,9 @@ def get_user_agent(
     if arch == "AMD64":
         arch = "x86_64"
 
-    system_info = f"{system}/{release} {arch}" if client_system is None else client_system
+    system_info = (
+        f"{system}/{release} {arch}" if client_system is None else client_system
+    )
     client = "spicepy" if client_name is None else client_name
     return f"{client}/{package_version} ({system_info})"
 

--- a/spicepy/config.py
+++ b/spicepy/config.py
@@ -1,7 +1,6 @@
 import os
 import platform
 from importlib.metadata import version
-from typing import Optional
 
 
 DEFAULT_FLIGHT_URL = os.environ.get("SPICE_FLIGHT_URL", "grpc+tls://flight.spiceai.io")
@@ -20,7 +19,7 @@ DEFAULT_LOCAL_HTTP_URL = os.environ.get("SPICE_LOCAL_HTTP_URL", "http://localhos
 #   Default is the system information of the current system, e.g. `Linux/5.4.0-1043-aws x86_64`.
 ###
 def get_user_agent(
-    client_name: Optional[str] = None, client_version: Optional[str] = None, client_system: Optional[str] = None
+    client_name: str | None = None, client_version: str | None = None, client_system: str | None = None
 ) -> str:
     package_version = version("spicepy") if client_version is None else client_version
     system = platform.system()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,21 +2,26 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Generator
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 
 # ============== Markers ==============
 
 
 def pytest_configure(config: pytest.Config) -> None:
     """Register custom markers."""
-    config.addinivalue_line("markers", "unit: Unit tests that don't require external services")
-    config.addinivalue_line("markers", "integration: Integration tests that require Spice runtime")
-    config.addinivalue_line("markers", "cloud: Tests that require Spice.ai cloud connection")
+    config.addinivalue_line(
+        "markers", "unit: Unit tests that don't require external services"
+    )
+    config.addinivalue_line(
+        "markers", "integration: Integration tests that require Spice runtime"
+    )
+    config.addinivalue_line(
+        "markers", "cloud: Tests that require Spice.ai cloud connection"
+    )
     config.addinivalue_line("markers", "slow: Tests that take a long time to run")
 
 
@@ -55,7 +60,9 @@ def is_adbc_available() -> bool:
         return False
 
 
-skip_if_no_adbc = pytest.mark.skipif(not is_adbc_available(), reason="ADBC driver not installed")
+skip_if_no_adbc = pytest.mark.skipif(
+    not is_adbc_available(), reason="ADBC driver not installed"
+)
 
 
 # ============== Mock Fixtures ==============

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import os
-import threading
 from pathlib import Path
+import threading
 from unittest.mock import MagicMock, patch
 
 import pyarrow as pa
@@ -98,7 +98,10 @@ class TestClientInit:
         mock_cert.tls_root_certs = b"cert"
         mock_cert_class.return_value = mock_cert
 
-        client = Client(flight_url="grpc+tls://custom.spiceai.io", http_url="https://custom-data.spiceai.io")
+        client = Client(
+            flight_url="grpc+tls://custom.spiceai.io",
+            http_url="https://custom-data.spiceai.io",
+        )
 
         assert client._flight_url == "grpc+tls://custom.spiceai.io"
 
@@ -340,7 +343,9 @@ class TestClientQueryWithParams:
         client = Client(flight_url="grpc://localhost:50051", api_key="test-key")
         result = client.query_with_params("SELECT * FROM t WHERE id = $1", [42])
 
-        mock_adbc.query_with_params.assert_called_once_with("SELECT * FROM t WHERE id = $1", [42])
+        mock_adbc.query_with_params.assert_called_once_with(
+            "SELECT * FROM t WHERE id = $1", [42]
+        )
         assert result == mock_reader
 
     @patch("spicepy._client._SpiceFlight")
@@ -781,7 +786,9 @@ class TestSpiceFlight:
         )
 
         # Mock the _threaded_flight_do_get method directly
-        with patch.object(flight_instance, "_threaded_flight_do_get", return_value=mock_reader):
+        with patch.object(
+            flight_instance, "_threaded_flight_do_get", return_value=mock_reader
+        ):
             result = flight_instance.query("SELECT 1")
 
         assert result is mock_reader
@@ -814,7 +821,9 @@ class TestSpiceFlight:
         )
 
         # Mock the _threaded_flight_do_get method directly
-        with patch.object(flight_instance, "_threaded_flight_do_get", return_value=mock_reader):
+        with patch.object(
+            flight_instance, "_threaded_flight_do_get", return_value=mock_reader
+        ):
             flight_instance.query("SELECT 1", timeout=60)
 
     @patch("spicepy._client.flight")
@@ -878,7 +887,9 @@ class TestSpiceFlight:
                 raise FlightUnauthenticatedError("")
             return mock_reader
 
-        with patch.object(flight_instance, "_threaded_flight_do_get", side_effect=mock_threaded_do_get):
+        with patch.object(
+            flight_instance, "_threaded_flight_do_get", side_effect=mock_threaded_do_get
+        ):
             result = flight_instance.query("SELECT 1")
 
         assert result == mock_reader

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,22 +33,32 @@ class TestDefaultUrls:
     def test_default_local_flight_url(self) -> None:
         """Test default local Flight URL."""
         assert DEFAULT_LOCAL_FLIGHT_URL is not None
-        assert "localhost" in DEFAULT_LOCAL_FLIGHT_URL or "127.0.0.1" in DEFAULT_LOCAL_FLIGHT_URL
+        assert (
+            "localhost" in DEFAULT_LOCAL_FLIGHT_URL
+            or "127.0.0.1" in DEFAULT_LOCAL_FLIGHT_URL
+        )
         assert "50051" in DEFAULT_LOCAL_FLIGHT_URL
 
     def test_default_local_http_url(self) -> None:
         """Test default local HTTP URL."""
         assert DEFAULT_LOCAL_HTTP_URL is not None
-        assert "localhost" in DEFAULT_LOCAL_HTTP_URL or "127.0.0.1" in DEFAULT_LOCAL_HTTP_URL
+        assert (
+            "localhost" in DEFAULT_LOCAL_HTTP_URL
+            or "127.0.0.1" in DEFAULT_LOCAL_HTTP_URL
+        )
         assert "8090" in DEFAULT_LOCAL_HTTP_URL
 
     def test_flight_url_format(self) -> None:
         """Test Flight URL has proper gRPC format."""
-        assert DEFAULT_LOCAL_FLIGHT_URL.startswith("grpc://") or DEFAULT_LOCAL_FLIGHT_URL.startswith("grpc+tls://")
+        assert DEFAULT_LOCAL_FLIGHT_URL.startswith(
+            "grpc://"
+        ) or DEFAULT_LOCAL_FLIGHT_URL.startswith("grpc+tls://")
 
     def test_http_url_format(self) -> None:
         """Test HTTP URL has proper HTTP format."""
-        assert DEFAULT_LOCAL_HTTP_URL.startswith("http://") or DEFAULT_LOCAL_HTTP_URL.startswith("https://")
+        assert DEFAULT_LOCAL_HTTP_URL.startswith(
+            "http://"
+        ) or DEFAULT_LOCAL_HTTP_URL.startswith("https://")
 
 
 class TestGetUserAgent:
@@ -59,7 +69,9 @@ class TestGetUserAgent:
         ua = get_user_agent()
         # Format: spicepy/x.y.z (System/release arch)
         pattern = r"spicepy/\d+\.\d+\.\d+ \([^)]+\)"
-        assert re.match(pattern, ua), f"User agent '{ua}' doesn't match expected pattern"
+        assert re.match(
+            pattern, ua
+        ), f"User agent '{ua}' doesn't match expected pattern"
 
     def test_user_agent_contains_version(self) -> None:
         """Test user agent contains version number."""
@@ -69,7 +81,9 @@ class TestGetUserAgent:
     def test_user_agent_contains_system_info(self) -> None:
         """Test user agent contains system information."""
         ua = get_user_agent()
-        assert "(" in ua and ")" in ua, "User agent should contain system info in parentheses"
+        assert (
+            "(" in ua and ")" in ua
+        ), "User agent should contain system info in parentheses"
 
     def test_custom_client_name(self) -> None:
         """Test custom client name."""
@@ -89,7 +103,11 @@ class TestGetUserAgent:
 
     def test_all_custom_values(self) -> None:
         """Test all custom values together."""
-        ua = get_user_agent(client_name="test-client", client_version="2.0.0", client_system="TestOS/1.0 test_arch")
+        ua = get_user_agent(
+            client_name="test-client",
+            client_version="2.0.0",
+            client_system="TestOS/1.0 test_arch",
+        )
         assert ua == "test-client/2.0.0 (TestOS/1.0 test_arch)"
 
     def test_custom_name_with_default_version(self) -> None:
@@ -114,7 +132,9 @@ class TestSpiceUserAgentConstant:
     def test_constant_format(self) -> None:
         """Test SPICE_USER_AGENT format."""
         pattern = r"spicepy/\d+\.\d+\.\d+ \((Linux|Windows|Darwin)/[\d\w\.\-\_]+ (x86_64|aarch64|i386|arm64|AMD64)\)"
-        assert re.match(pattern, SPICE_USER_AGENT), f"SPICE_USER_AGENT '{SPICE_USER_AGENT}' doesn't match pattern"
+        assert re.match(
+            pattern, SPICE_USER_AGENT
+        ), f"SPICE_USER_AGENT '{SPICE_USER_AGENT}' doesn't match pattern"
 
     def test_constant_matches_get_user_agent(self) -> None:
         """Test SPICE_USER_AGENT equals get_user_agent() default."""

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -62,7 +62,9 @@ class TestSpiceAIError:
 
     def test_error_with_special_characters(self) -> None:
         """Test SpiceAIError with special characters."""
-        msg = "Error: connection failed\nDetails: timeout at 10.0.0.1:50051\tRetry: true"
+        msg = (
+            "Error: connection failed\nDetails: timeout at 10.0.0.1:50051\tRetry: true"
+        )
         error = SpiceAIError(msg)
         assert error.message == msg
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -40,7 +40,11 @@ class TestRefreshOpts:
 
     def test_with_all_options(self) -> None:
         """Test RefreshOpts with all options."""
-        opts = RefreshOpts(refresh_sql="SELECT * FROM table", refresh_mode="incremental", refresh_jitter_max="10s")
+        opts = RefreshOpts(
+            refresh_sql="SELECT * FROM table",
+            refresh_mode="incremental",
+            refresh_jitter_max="10s",
+        )
         assert opts.refresh_sql == "SELECT * FROM table"
         assert opts.refresh_mode == "incremental"
         assert opts.refresh_jitter_max == "10s"
@@ -57,7 +61,9 @@ class TestRefreshOpts:
 
     def test_to_dict_with_values(self) -> None:
         """Test RefreshOpts to_dict with values."""
-        opts = RefreshOpts(refresh_sql="SELECT 1", refresh_mode="full", refresh_jitter_max="1h")
+        opts = RefreshOpts(
+            refresh_sql="SELECT 1", refresh_mode="full", refresh_jitter_max="1h"
+        )
         d = opts.to_dict()
         assert d["refresh_sql"] == "SELECT 1"
         assert d["refresh_mode"] == "full"
@@ -149,7 +155,9 @@ class TestHttpRequestsInit:
         mock_session.headers = {}
         mock_session_class.return_value = mock_session
 
-        HttpRequests("http://example.com", {"X-API-Key": "secret", "Accept": "application/json"})
+        HttpRequests(
+            "http://example.com", {"X-API-Key": "secret", "Accept": "application/json"}
+        )
         # Should have the provided headers plus default user-agent
         assert mock_session.headers["X-API-Key"] == "secret"
         assert mock_session.headers["Accept"] == "application/json"
@@ -166,7 +174,9 @@ class TestHttpRequestsInit:
         assert mock_session.headers.get("user-agent") == SPICE_USER_AGENT
 
     @patch("spicepy._http.Session")
-    def test_init_preserves_custom_user_agent(self, mock_session_class: MagicMock) -> None:
+    def test_init_preserves_custom_user_agent(
+        self, mock_session_class: MagicMock
+    ) -> None:
         """Test HttpRequests preserves custom user agent."""
         mock_session = MagicMock()
         mock_session.headers = {"user-agent": "custom-agent"}
@@ -226,7 +236,12 @@ class TestHttpRequestsPrepareParam:
 
         http = HttpRequests("http://example.com", {})
         dt = datetime.datetime(2024, 1, 15, 12, 0, 0)
-        params = {"name": "test", "count": 10, "timestamp": dt, "duration": datetime.timedelta(minutes=5)}
+        params = {
+            "name": "test",
+            "count": 10,
+            "timestamp": dt,
+            "duration": datetime.timedelta(minutes=5),
+        }
         result = http.prepare_param(params)
         assert result["name"] == "test"
         assert result["count"] == 10
@@ -345,7 +360,9 @@ class TestHttpRequestsSendRequest:
         mock_session_class.return_value = mock_session
 
         http = HttpRequests("http://example.com", {})
-        result = http.send_request("GET", "/api/search", param={"q": "test", "limit": 10})
+        result = http.send_request(
+            "GET", "/api/search", param={"q": "test", "limit": 10}
+        )
 
         assert result == {"data": []}
 
@@ -364,7 +381,9 @@ class TestHttpRequestsSendRequest:
 
         # Verify headers were merged
         call_kwargs = mock_session.get.call_args
-        assert "X-Custom" in call_kwargs.kwargs.get("headers", {}) or "headers" in str(call_kwargs)
+        assert "X-Custom" in call_kwargs.kwargs.get("headers", {}) or "headers" in str(
+            call_kwargs
+        )
 
 
 class TestHttpRequestsRetryConfiguration:
@@ -372,7 +391,9 @@ class TestHttpRequestsRetryConfiguration:
 
     @patch("spicepy._http.Session")
     @patch("spicepy._http.HTTPAdapter")
-    def test_retry_adapter_mounted(self, mock_adapter_class: MagicMock, mock_session_class: MagicMock) -> None:
+    def test_retry_adapter_mounted(
+        self, mock_adapter_class: MagicMock, mock_session_class: MagicMock
+    ) -> None:
         """Test retry adapter is mounted for HTTPS."""
         mock_session = MagicMock()
         mock_session.headers = {}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,11 +8,18 @@ import pytest
 import requests
 
 from spicepy import Client, RefreshOpts
-from spicepy.config import DEFAULT_LOCAL_FLIGHT_URL, DEFAULT_LOCAL_HTTP_URL, SPICE_USER_AGENT, get_user_agent
+from spicepy.config import (
+    DEFAULT_LOCAL_FLIGHT_URL,
+    DEFAULT_LOCAL_HTTP_URL,
+    SPICE_USER_AGENT,
+    get_user_agent,
+)
 from spicepy.params import infer_arrow_type
 
 
-def wait_for_ready(http_url: str = DEFAULT_LOCAL_HTTP_URL, timeout: int = 60, interval: float = 1.0) -> bool:
+def wait_for_ready(
+    http_url: str = DEFAULT_LOCAL_HTTP_URL, timeout: int = 60, interval: float = 1.0
+) -> bool:
     """Wait for the Spice runtime to be ready by polling the /v1/ready endpoint.
 
     Args:
@@ -41,7 +48,9 @@ def wait_for_ready(http_url: str = DEFAULT_LOCAL_HTTP_URL, timeout: int = 60, in
 # Skip cloud tests if TEST_SPICE_CLOUD is not set to true
 def skip_cloud():
     skip = os.environ.get("TEST_SPICE_CLOUD") != "true"
-    return pytest.mark.skipif(skip, reason="Cloud tests disabled (set TEST_SPICE_CLOUD=true)")
+    return pytest.mark.skipif(
+        skip, reason="Cloud tests disabled (set TEST_SPICE_CLOUD=true)"
+    )
 
 
 def get_cloud_client():
@@ -173,9 +182,12 @@ def test_local_runtime_refresh():
 def test_user_agent(httpserver):
     reply = {"message": "OK"}
     httpserver.expect_request(
-        "/v1/datasets/test/acceleration/refresh", headers={"User-Agent": SPICE_USER_AGENT}
+        "/v1/datasets/test/acceleration/refresh",
+        headers={"User-Agent": SPICE_USER_AGENT},
     ).respond_with_data(json.dumps(reply), content_type="application/json")
-    client = Client(flight_url=DEFAULT_LOCAL_FLIGHT_URL, http_url=httpserver.url_for("/"))
+    client = Client(
+        flight_url=DEFAULT_LOCAL_FLIGHT_URL, http_url=httpserver.url_for("/")
+    )
     response = client.refresh_dataset("test")
     httpserver.check_assertions()
     assert response == reply
@@ -183,16 +195,25 @@ def test_user_agent(httpserver):
     httpserver.expect_request(
         "/v1/datasets/test/acceleration/refresh", headers={"User-Agent": "custom-agent"}
     ).respond_with_data(json.dumps(reply), content_type="application/json")
-    client = Client(flight_url=DEFAULT_LOCAL_FLIGHT_URL, http_url=httpserver.url_for("/"), user_agent="custom-agent")
+    client = Client(
+        flight_url=DEFAULT_LOCAL_FLIGHT_URL,
+        http_url=httpserver.url_for("/"),
+        user_agent="custom-agent",
+    )
     response = client.refresh_dataset("test")
     httpserver.check_assertions()
     assert response == reply
 
     custom_ua = get_user_agent("custom-client", "1.0.0", "custom-system")
     httpserver.expect_request(
-        "/v1/datasets/test/acceleration/refresh", headers={"User-Agent": "custom-client/1.0.0 (custom-system)"}
+        "/v1/datasets/test/acceleration/refresh",
+        headers={"User-Agent": "custom-client/1.0.0 (custom-system)"},
     ).respond_with_data(json.dumps(reply), content_type="application/json")
-    client = Client(flight_url=DEFAULT_LOCAL_FLIGHT_URL, http_url=httpserver.url_for("/"), user_agent=custom_ua)
+    client = Client(
+        flight_url=DEFAULT_LOCAL_FLIGHT_URL,
+        http_url=httpserver.url_for("/"),
+        user_agent=custom_ua,
+    )
     response = client.refresh_dataset("test")
     httpserver.check_assertions()
     assert response == reply
@@ -323,7 +344,8 @@ def test_parameterized_query_with_explicit_types():
     client = get_local_client()
 
     reader = client.query_with_params(
-        "SELECT trip_distance, fare_amount FROM taxi_trips WHERE trip_distance > $1 LIMIT 5", [(10.0, pa.float64())]
+        "SELECT trip_distance, fare_amount FROM taxi_trips WHERE trip_distance > $1 LIMIT 5",
+        [(10.0, pa.float64())],
     )
 
     total_rows = 0
@@ -355,7 +377,9 @@ def test_parameterized_query_no_params():
     """Test parameterized query method with no parameters (regular query)."""
     client = get_local_client()
 
-    reader = client.query_with_params("SELECT trip_distance, fare_amount FROM taxi_trips LIMIT 5", [])
+    reader = client.query_with_params(
+        "SELECT trip_distance, fare_amount FROM taxi_trips LIMIT 5", []
+    )
 
     total_rows = 0
     for batch in reader:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -546,7 +546,7 @@ def test_cloud_parameterized_query_aggregation():
     reader = client.query_with_params(
         """SELECT o_orderstatus,
                   COUNT(*) as order_count,
-                  AVG(o_totalprice) as avg_price,
+                  CAST(AVG(o_totalprice) AS DOUBLE) as avg_price,
                   SUM(o_totalprice) as total_price
            FROM tpch.orders
            WHERE o_orderstatus = $1


### PR DESCRIPTION
## Summary
- Upgrade all Python dependencies across `pyproject.toml`, `requirements.txt`, and `setup.py` to their latest versions
- Major version bumps: pyarrow 18→23, pandas 2→3, pytest 8→9, pylint 3→4, pytest-cov 5→7
- Minor/patch bumps: ruff 0.4→0.15, mypy 1.10→1.20, certifi, requests, flake8, bandit, ADBC drivers, setuptools, build, and more

## Test plan
- [ ] Verify CI passes (lint, type-check, unit tests)
- [ ] Confirm no breaking changes from pandas 3.x in library code
- [ ] Confirm no breaking changes from pytest 9.x in test suite