### PR TITLE
feat: add mTLS client certificate support

### DIFF
--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -236,8 +236,32 @@ class _SpiceFlight:
             )
         return (str.encode("user-agent"), str.encode(config.SPICE_USER_AGENT))
 
-    def __init__(self, grpc: str, api_key: str, tls_root_certs, user_agent=None):
-        self._flight_client = flight.connect(grpc, tls_root_certs=tls_root_certs)
+    def __init__(
+        self,
+        grpc: str,
+        api_key: str,
+        tls_root_certs,
+        user_agent=None,
+        tls_client_certificate: str | Path | None = None,
+        tls_client_key: str | Path | None = None,
+    ):
+        connect_kwargs = {"tls_root_certs": tls_root_certs}
+        if tls_client_certificate is not None and tls_client_key is not None:
+            cert_path = (
+                tls_client_certificate
+                if isinstance(tls_client_certificate, Path)
+                else Path(tls_client_certificate)
+            )
+            key_path = (
+                tls_client_key
+                if isinstance(tls_client_key, Path)
+                else Path(tls_client_key)
+            )
+            with open(cert_path, "rb") as f:
+                connect_kwargs["cert_chain"] = f.read()
+            with open(key_path, "rb") as f:
+                connect_kwargs["private_key"] = f.read()
+        self._flight_client = flight.connect(grpc, **connect_kwargs)
         self._api_key = api_key
         self.headers = [_SpiceFlight._user_agent(user_agent)]
         self._flight_options = flight.FlightCallOptions(
@@ -312,17 +336,39 @@ class Client:
         http_url: str = config.DEFAULT_HTTP_URL,
         tls_root_cert: str | Path | None = None,
         user_agent: str | None = None,
+        tls_client_certificate: str | Path | None = None,
+        tls_client_key: str | Path | None = None,
     ):  # pylint: disable=R0913
+        # Validate that client cert and key are either both set or both unset
+        has_cert = tls_client_certificate is not None
+        has_key = tls_client_key is not None
+        if has_cert != has_key:
+            missing = "tls_client_key" if has_cert else "tls_client_certificate"
+            raise ValueError(
+                f"Both tls_client_certificate and tls_client_key must be "
+                f"provided together for mTLS. {missing} is missing."
+            )
+
         tls_root_certs = _Cert(tls_root_cert).tls_root_certs
         self._flight = _SpiceFlight(
-            flight_url, api_key or "", tls_root_certs, user_agent
+            flight_url,
+            api_key or "",
+            tls_root_certs,
+            user_agent,
+            tls_client_certificate=tls_client_certificate,
+            tls_client_key=tls_client_key,
         )
 
         self.api_key = api_key
         self._flight_url = flight_url
         self._user_agent = user_agent
         self._adbc_client: _ADBCClient | None = None
-        self.http = HttpRequests(http_url, self._headers(user_agent))
+        self.http = HttpRequests(
+            http_url,
+            self._headers(user_agent),
+            tls_client_certificate=tls_client_certificate,
+            tls_client_key=tls_client_key,
+        )
 
     def _headers(self, user_agent=None) -> dict[str, str]:
         headers = {

--- a/spicepy/_http.py
+++ b/spicepy/_http.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 import datetime
+from pathlib import Path
 from typing import Any, Literal
 
 from requests import Response, Session
@@ -28,12 +29,22 @@ HttpMethod = Literal["POST", "GET", "PUT", "HEAD", "POST"]
 
 
 class HttpRequests:
-    def __init__(self, base_url: str, headers: dict[str, str]) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        headers: dict[str, str],
+        tls_client_certificate: str | Path | None = None,
+        tls_client_key: str | Path | None = None,
+    ) -> None:
         self.session = self._create_session(headers)
 
         # set the user-agent header
         if "user-agent" not in self.session.headers:
             self.session.headers["user-agent"] = SPICE_USER_AGENT
+
+        # Configure client certificate for mTLS on HTTP requests
+        if tls_client_certificate is not None and tls_client_key is not None:
+            self.session.cert = (str(tls_client_certificate), str(tls_client_key))
 
         self.base_url = base_url
 


### PR DESCRIPTION
Adds mTLS (mutual TLS) client certificate support, allowing the SDK to present a client certificate during the TLS handshake when connecting to a Spice runtime with `client_auth_mode: request` or `client_auth_mode: required`.

## Usage

Provide the paths to a PEM-encoded client certificate and private key file when building the client. The certificate is presented to the server during the TLS handshake.

## Notes

- mTLS is an [Enterprise](https://docs.spice.ai/docs/enterprise) feature of the Spice runtime.
- Both the certificate and key file must be provided together.
- When not set, the client behaves exactly as before (standard TLS).
- See the [mTLS cookbook recipe](https://github.com/spiceai/cookbook/tree/trunk/mtls) for a complete walkthrough.