### PR TITLE
feat: expand DataFrame/Expr analytics coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,6 +150,28 @@ jobs:
           echo "Spice runtime did not become ready within 120 seconds"
           exit 1
 
+      # The Windows readiness poll above runs inside WSL and only checks the
+      # HTTP port (8090). WSL2 forwards ports to the Windows host asynchronously,
+      # so 8090-ready in WSL does not guarantee the host can reach the Flight
+      # port (50051) yet — the tests run on the host and hit 50051, which raced
+      # into "connection refused". Gate the tests on host-side Flight reachability.
+      - name: Wait for Flight endpoint from host (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          python - <<'PY'
+          import socket, sys, time
+          for i in range(60):
+              try:
+                  with socket.create_connection(("127.0.0.1", 50051), timeout=2):
+                      print("Flight port 50051 reachable from host")
+                      sys.exit(0)
+              except OSError:
+                  print(f"waiting for Flight 50051 from host... ({i + 1}/60)")
+                  time.sleep(1)
+          sys.exit("Flight port 50051 never became reachable from host")
+          PY
+
       - name: Running tests
         env:
           API_KEY: ${{ secrets.API_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,20 +76,17 @@ jobs:
         run: |
           pip install ".[test]"
 
-      - name: Install Spice (https://install.spiceai.org) (Linux)
-        if: matrix.os == 'ubuntu-latest'
+      # Linux and macOS both use the official cross-platform installer. The
+      # Homebrew formula's post-install ("Upgrading Spice Runtime...") fails
+      # intermittently on macOS runners, so brew is avoided here entirely.
+      - name: Install Spice (https://install.spiceai.org) (Linux & macOS)
+        if: matrix.os != 'windows-latest'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           curl https://install.spiceai.org | /bin/bash
           echo "$HOME/.spice/bin" >> $GITHUB_PATH
           $HOME/.spice/bin/spice install
-
-      - name: Install Spice (https://install.spiceai.org) (MacOS)
-        if: matrix.os == 'macos-latest'
-        run: |
-          brew install spiceai/spiceai/spice
-          brew install spiceai/spiceai/spiced
 
       # Spice on Windows is only supported via WSL. Set up Ubuntu under WSL
       # and install Spice there; the tests on the Windows host then talk to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,11 @@ polars = [
 # ============== Tool Configuration ==============
 
 [tool.mypy]
-python_version = "3.11"
+# No explicit python_version: mypy targets the running interpreter, so each CI
+# matrix job (3.11–3.14) type-checks against its own version and the 3.11 job
+# still enforces the 3.11 floor. Pinning to 3.11 made mypy reject PEP 695 `type`
+# statements that recent third-party stubs (e.g. numpy) ship when checked on
+# Python 3.12+.
 warn_return_any = true
 warn_unused_configs = true
 warn_redundant_casts = true

--- a/spicepy/__init__.py
+++ b/spicepy/__init__.py
@@ -8,7 +8,7 @@ Spice.ai client library.
 from . import functions
 from ._client import Client
 from ._dataframe import SpiceDataFrame
-from ._expr import Expr, case, col, lit
+from ._expr import Expr, WindowFrame, case, col, lit
 from ._http import RefreshOpts
 
 __all__ = [
@@ -16,6 +16,7 @@ __all__ = [
     "Expr",
     "RefreshOpts",
     "SpiceDataFrame",
+    "WindowFrame",
     "case",
     "col",
     "functions",

--- a/spicepy/_dataframe.py
+++ b/spicepy/_dataframe.py
@@ -285,6 +285,22 @@ class SpiceDataFrame:
         df = self.to_pandas()
         print(df.to_string(index=False))  # noqa: T201
 
+    # ------------------------------------------------------------------
+    # Writers
+    # ------------------------------------------------------------------
+
+    def write_parquet(self, path: str, **kwargs: Any) -> None:
+        """Stream this DataFrame's result to a Parquet file at ``path``."""
+        self._client.write_parquet(self._sql, path, **kwargs)
+
+    def write_csv(self, path: str, **kwargs: Any) -> None:
+        """Stream this DataFrame's result to a CSV file at ``path``."""
+        self._client.write_csv(self._sql, path, **kwargs)
+
+    def write_json(self, path: str) -> None:
+        """Write this DataFrame's result to ``path`` as newline-delimited JSON."""
+        self._client.write_json(self._sql, path)
+
     def __repr__(self) -> str:
         return f"SpiceDataFrame({self._sql})"
 

--- a/spicepy/_expr.py
+++ b/spicepy/_expr.py
@@ -43,6 +43,10 @@ class Expr:
     def cast(self, arrow_type: Any) -> Expr:
         return _Cast(self, _arrow_type_to_sql(arrow_type))
 
+    def try_cast(self, arrow_type: Any) -> Expr:
+        """Like :meth:`cast` but yields NULL instead of erroring on failure."""
+        return _Cast(self, _arrow_type_to_sql(arrow_type), is_try=True)
+
     # --- comparison (DSL: returns Expr, not bool — see class docstring) ---
 
     def __eq__(self, other: object) -> Expr:  # type: ignore[override]
@@ -124,6 +128,20 @@ class Expr:
 
     def between(self, lo: Any, hi: Any) -> Expr:
         return _Between(self, _coerce(lo), _coerce(hi))
+
+    # --- pattern matching ---
+
+    def like(self, pattern: Any) -> Expr:
+        return _BinOp(self, "LIKE", _coerce(pattern))
+
+    def ilike(self, pattern: Any) -> Expr:
+        return _BinOp(self, "ILIKE", _coerce(pattern))
+
+    def not_like(self, pattern: Any) -> Expr:
+        return _BinOp(self, "NOT LIKE", _coerce(pattern))
+
+    def not_ilike(self, pattern: Any) -> Expr:
+        return _BinOp(self, "NOT ILIKE", _coerce(pattern))
 
     # --- sort qualifier (used inside sort()/order_by) ---
 
@@ -272,39 +290,60 @@ class _Alias(Expr):
 
 
 class _Cast(Expr):
-    __slots__ = ("inner", "type_sql")
+    __slots__ = ("inner", "is_try", "type_sql")
 
-    def __init__(self, inner: Expr, type_sql: str) -> None:
+    def __init__(self, inner: Expr, type_sql: str, is_try: bool = False) -> None:
         self.inner = inner
         self.type_sql = type_sql
+        self.is_try = is_try
 
     def to_sql(self) -> str:
-        return f"CAST({self.inner.to_sql()} AS {self.type_sql})"
+        func = "TRY_CAST" if self.is_try else "CAST"
+        return f"{func}({self.inner.to_sql()} AS {self.type_sql})"
 
 
 class _Func(Expr):
     """A scalar/aggregate function call: ``name(arg, arg, ...)``."""
 
-    __slots__ = ("args", "distinct", "name")
+    __slots__ = ("args", "distinct", "filter_pred", "name")
 
-    def __init__(self, name: str, args: list[Expr], distinct: bool = False) -> None:
+    def __init__(
+        self,
+        name: str,
+        args: list[Expr],
+        distinct: bool = False,
+        filter_pred: Expr | None = None,
+    ) -> None:
         self.name = name
         self.args = args
         self.distinct = distinct
+        self.filter_pred = filter_pred
 
     def to_sql(self) -> str:
         prefix = "DISTINCT " if self.distinct else ""
         if not self.args:
-            return f"{self.name}()"
-        rendered = ", ".join(a.to_sql() for a in self.args)
-        return f"{self.name}({prefix}{rendered})"
+            call = f"{self.name}()"
+        else:
+            rendered = ", ".join(a.to_sql() for a in self.args)
+            call = f"{self.name}({prefix}{rendered})"
+        if self.filter_pred is not None:
+            call = f"{call} FILTER (WHERE {self.filter_pred.to_sql()})"
+        return call
+
+    def filter(self, predicate: Expr) -> _Func:
+        """Attach a ``FILTER (WHERE ...)`` clause to this aggregate call.
+
+        Example: ``F.sum(col("amt")).filter(col("status") == "paid")``.
+        """
+        return _Func(self.name, self.args, self.distinct, filter_pred=predicate)
 
     def over(
         self,
         partition_by: list[Expr] | None = None,
         order_by: list[Expr | _SortExpr] | None = None,
+        frame: WindowFrame | None = None,
     ) -> Expr:
-        return _Window(self, partition_by or [], order_by or [])
+        return _Window(self, partition_by or [], order_by or [], frame)
 
 
 class _Case(Expr):
@@ -337,17 +376,19 @@ class _Case(Expr):
 
 
 class _Window(Expr):
-    __slots__ = ("func", "order_by", "partition_by")
+    __slots__ = ("frame", "func", "order_by", "partition_by")
 
     def __init__(
         self,
         func: _Func,
         partition_by: list[Expr],
         order_by: list[Expr | _SortExpr],
+        frame: WindowFrame | None = None,
     ) -> None:
         self.func = func
         self.partition_by = partition_by
         self.order_by = order_by
+        self.frame = frame
 
     def to_sql(self) -> str:
         parts = []
@@ -357,7 +398,71 @@ class _Window(Expr):
             )
         if self.order_by:
             parts.append("ORDER BY " + ", ".join(_sort_sql(e) for e in self.order_by))
+        if self.frame is not None:
+            parts.append(self.frame.to_sql())
         return f"{self.func.to_sql()} OVER ({' '.join(parts)})"
+
+
+class WindowFrame:
+    """A window frame: ``ROWS|RANGE|GROUPS BETWEEN <start> AND <end>``.
+
+    Passed to :meth:`Expr.over` to bound a window function (running totals,
+    moving averages). Bounds follow the datafusion-python convention:
+
+    * ``None`` — unbounded (``UNBOUNDED PRECEDING`` at the start,
+      ``UNBOUNDED FOLLOWING`` at the end).
+    * ``0`` — ``CURRENT ROW``.
+    * ``n > 0`` — ``n PRECEDING`` at the start, ``n FOLLOWING`` at the end.
+
+    Example — a trailing 7-row moving average::
+
+        F.avg(col("v")).over(
+            order_by=[col("ts")],
+            frame=WindowFrame("rows", 6, 0),
+        )
+    """
+
+    __slots__ = ("end_bound", "start_bound", "units")
+
+    _UNITS = ("rows", "range", "groups")
+
+    def __init__(
+        self,
+        units: str,
+        start_bound: int | None = None,
+        end_bound: int | None = None,
+    ) -> None:
+        normalized = units.lower()
+        if normalized not in self._UNITS:
+            raise ValueError(
+                f"Unknown window frame units {units!r}; "
+                f"expected one of {list(self._UNITS)}"
+            )
+        if start_bound is not None and start_bound < 0:
+            raise ValueError("start_bound must be None or a non-negative integer")
+        if end_bound is not None and end_bound < 0:
+            raise ValueError("end_bound must be None or a non-negative integer")
+        self.units = normalized
+        self.start_bound = start_bound
+        self.end_bound = end_bound
+
+    def to_sql(self) -> str:
+        return (
+            f"{self.units.upper()} BETWEEN "
+            f"{self._bound_sql(self.start_bound, 'PRECEDING')} AND "
+            f"{self._bound_sql(self.end_bound, 'FOLLOWING')}"
+        )
+
+    @staticmethod
+    def _bound_sql(bound: int | None, direction: str) -> str:
+        if bound is None:
+            return f"UNBOUNDED {direction}"
+        if bound == 0:
+            return "CURRENT ROW"
+        return f"{bound} {direction}"
+
+    def __repr__(self) -> str:
+        return f"WindowFrame({self.to_sql()})"
 
 
 class _SortExpr:

--- a/spicepy/functions.py
+++ b/spicepy/functions.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from ._expr import Expr, _Case, _coerce, _Func, _Raw
 from ._expr import case as _case_builder
+from ._sql import quote_literal
 
 
 def _fn(name: str, *args: Any) -> Expr:
@@ -80,6 +81,67 @@ def approx_distinct(expr: Any) -> Expr:
 
 def array_agg(expr: Any) -> Expr:
     return _fn("ARRAY_AGG", expr)
+
+
+def stddev_pop(expr: Any) -> Expr:
+    return _fn("STDDEV_POP", expr)
+
+
+def stddev_samp(expr: Any) -> Expr:
+    return _fn("STDDEV_SAMP", expr)
+
+
+def var_pop(expr: Any) -> Expr:
+    return _fn("VAR_POP", expr)
+
+
+def var_samp(expr: Any) -> Expr:
+    return _fn("VAR_SAMP", expr)
+
+
+def approx_median(expr: Any) -> Expr:
+    return _fn("APPROX_MEDIAN", expr)
+
+
+def approx_percentile_cont(expr: Any, percentile: Any) -> Expr:
+    """Approximate continuous percentile, e.g. ``approx_percentile_cont(col("x"), 0.95)``."""
+    return _fn("APPROX_PERCENTILE_CONT", expr, percentile)
+
+
+def corr(y: Any, x: Any) -> Expr:
+    return _fn("CORR", y, x)
+
+
+def covar_pop(y: Any, x: Any) -> Expr:
+    return _fn("COVAR_POP", y, x)
+
+
+def covar_samp(y: Any, x: Any) -> Expr:
+    return _fn("COVAR_SAMP", y, x)
+
+
+def string_agg(expr: Any, delimiter: Any) -> Expr:
+    return _fn("STRING_AGG", expr, delimiter)
+
+
+def bool_and(expr: Any) -> Expr:
+    return _fn("BOOL_AND", expr)
+
+
+def bool_or(expr: Any) -> Expr:
+    return _fn("BOOL_OR", expr)
+
+
+def bit_and(expr: Any) -> Expr:
+    return _fn("BIT_AND", expr)
+
+
+def bit_or(expr: Any) -> Expr:
+    return _fn("BIT_OR", expr)
+
+
+def bit_xor(expr: Any) -> Expr:
+    return _fn("BIT_XOR", expr)
 
 
 # --- math ---
@@ -193,6 +255,25 @@ def extract(part: Any, expr: Any) -> Expr:
     return date_part(part, expr)
 
 
+def interval(value: str) -> Expr:
+    """An INTERVAL literal: ``interval("1 day")`` -> ``INTERVAL '1 day'``."""
+    return _Raw("INTERVAL " + quote_literal(value))
+
+
+def date_bin(stride: Any, source: Any, origin: Any = None) -> Expr:
+    """Bin timestamps into fixed-width buckets (time-series downsampling).
+
+    ``stride`` may be an interval string (``"15 minutes"``) or an Expr. Example::
+
+        F.date_bin("1 hour", col("ts"))
+    """
+    stride_expr = interval(stride) if isinstance(stride, str) else _coerce(stride)
+    args = [stride_expr, _coerce(source)]
+    if origin is not None:
+        args.append(_coerce(origin))
+    return _Func("DATE_BIN", args)
+
+
 # --- null / control flow ---
 
 
@@ -208,6 +289,18 @@ def nullif(a: Any, b: Any) -> Expr:
 
 def ifnull(expr: Any, default: Any) -> Expr:
     return coalesce(expr, default)
+
+
+def greatest(*exprs: Any) -> Expr:
+    if not exprs:
+        raise ValueError("greatest requires at least one argument")
+    return _fn("GREATEST", *exprs)
+
+
+def least(*exprs: Any) -> Expr:
+    if not exprs:
+        raise ValueError("least requires at least one argument")
+    return _fn("LEAST", *exprs)
 
 
 def case() -> _Case:
@@ -236,6 +329,10 @@ def percent_rank() -> _Func:
 
 def cume_dist() -> _Func:
     return _Func("CUME_DIST", [])
+
+
+def ntile(n: Any) -> _Func:
+    return _Func("NTILE", [_coerce(n)])
 
 
 def lag(expr: Any, offset: Any = 1, default: Any = None) -> _Func:

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -254,6 +254,32 @@ class TestValuesDataFrame:
             values_dataframe(client, [{"a": 1}, {"b": 2}])
 
 
+class TestWriters:
+    def test_write_parquet_delegates(
+        self, df: SpiceDataFrame, client: MagicMock
+    ) -> None:
+        df.write_parquet("out.parquet")
+        client.write_parquet.assert_called_once_with(
+            'SELECT * FROM "trips"', "out.parquet"
+        )
+
+    def test_write_parquet_passes_kwargs(
+        self, df: SpiceDataFrame, client: MagicMock
+    ) -> None:
+        df.write_parquet("out.parquet", compression="snappy")
+        client.write_parquet.assert_called_once_with(
+            'SELECT * FROM "trips"', "out.parquet", compression="snappy"
+        )
+
+    def test_write_csv_delegates(self, df: SpiceDataFrame, client: MagicMock) -> None:
+        df.write_csv("out.csv")
+        client.write_csv.assert_called_once_with('SELECT * FROM "trips"', "out.csv")
+
+    def test_write_json_delegates(self, df: SpiceDataFrame, client: MagicMock) -> None:
+        df.write_json("out.json")
+        client.write_json.assert_called_once_with('SELECT * FROM "trips"', "out.json")
+
+
 class TestRepr:
     def test_repr(self, df: SpiceDataFrame) -> None:
         assert "SELECT" in repr(df)

--- a/tests/test_expr.py
+++ b/tests/test_expr.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pyarrow as pa
 import pytest
 
-from spicepy import case, col, lit
+from spicepy import WindowFrame, case, col, lit
 from spicepy._expr import _Raw
 
 
@@ -100,6 +100,22 @@ class TestPredicates:
         assert col("x").between(1, 10).to_sql() == '("x" BETWEEN 1 AND 10)'
 
 
+class TestPatternMatching:
+    def test_like(self) -> None:
+        assert col("name").like("%foo%").to_sql() == """("name" LIKE '%foo%')"""
+
+    def test_ilike(self) -> None:
+        assert col("name").ilike("%FOO%").to_sql() == """("name" ILIKE '%FOO%')"""
+
+    def test_not_like(self) -> None:
+        assert col("name").not_like("%bar%").to_sql() == """("name" NOT LIKE '%bar%')"""
+
+    def test_not_ilike(self) -> None:
+        assert (
+            col("name").not_ilike("%bar%").to_sql() == """("name" NOT ILIKE '%bar%')"""
+        )
+
+
 class TestAliasAndCast:
     def test_alias(self) -> None:
         assert col("x").alias("y").to_sql() == '"x" AS "y"'
@@ -119,6 +135,12 @@ class TestAliasAndCast:
     def test_cast_bad_type(self) -> None:
         with pytest.raises(TypeError):
             col("x").cast(object())
+
+    def test_try_cast_string(self) -> None:
+        assert col("x").try_cast("BIGINT").to_sql() == 'TRY_CAST("x" AS BIGINT)'
+
+    def test_try_cast_arrow_type(self) -> None:
+        assert col("x").try_cast(pa.int32()).to_sql() == 'TRY_CAST("x" AS INT)'
 
 
 class TestSortQualifier:
@@ -144,6 +166,43 @@ class TestCase:
     def test_no_branches_raises(self) -> None:
         with pytest.raises(ValueError, match="no WHEN"):
             case().to_sql()
+
+
+class TestWindowFrame:
+    def test_rows_unbounded_to_current(self) -> None:
+        assert (
+            WindowFrame("rows", None, 0).to_sql()
+            == "ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"
+        )
+
+    def test_rows_trailing_window(self) -> None:
+        assert (
+            WindowFrame("rows", 6, 0).to_sql()
+            == "ROWS BETWEEN 6 PRECEDING AND CURRENT ROW"
+        )
+
+    def test_range_unbounded_both(self) -> None:
+        assert (
+            WindowFrame("range").to_sql()
+            == "RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING"
+        )
+
+    def test_groups_centered(self) -> None:
+        assert (
+            WindowFrame("groups", 1, 1).to_sql()
+            == "GROUPS BETWEEN 1 PRECEDING AND 1 FOLLOWING"
+        )
+
+    def test_units_case_insensitive(self) -> None:
+        assert WindowFrame("ROWS", 0, 0).to_sql().startswith("ROWS BETWEEN")
+
+    def test_bad_units_raises(self) -> None:
+        with pytest.raises(ValueError, match="units"):
+            WindowFrame("bogus")
+
+    def test_negative_bound_raises(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            WindowFrame("rows", -1, 0)
 
 
 class TestRaw:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -76,6 +76,10 @@ class TestConditional:
         with pytest.raises(ValueError, match="at least one"):
             F.greatest()
 
+    def test_least_requires_arg(self) -> None:
+        with pytest.raises(ValueError, match="at least one"):
+            F.least()
+
 
 class TestMath:
     def test_abs(self) -> None:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from spicepy import col
+import pytest
+
+from spicepy import WindowFrame, col
 from spicepy import functions as F
 
 
@@ -25,6 +27,54 @@ class TestAggregates:
 
     def test_count_distinct(self) -> None:
         assert F.count_distinct(col("x")).to_sql() == 'COUNT(DISTINCT "x")'
+
+
+class TestAnalyticsAggregates:
+    def test_stddev_pop(self) -> None:
+        assert F.stddev_pop(col("x")).to_sql() == 'STDDEV_POP("x")'
+
+    def test_var_samp(self) -> None:
+        assert F.var_samp(col("x")).to_sql() == 'VAR_SAMP("x")'
+
+    def test_approx_percentile_cont(self) -> None:
+        assert (
+            F.approx_percentile_cont(col("x"), 0.95).to_sql()
+            == 'APPROX_PERCENTILE_CONT("x", 0.95)'
+        )
+
+    def test_corr(self) -> None:
+        assert F.corr(col("y"), col("x")).to_sql() == 'CORR("y", "x")'
+
+    def test_string_agg(self) -> None:
+        assert F.string_agg(col("c"), ", ").to_sql() == """STRING_AGG("c", ', ')"""
+
+    def test_bool_and(self) -> None:
+        assert F.bool_and(col("f")).to_sql() == 'BOOL_AND("f")'
+
+    def test_bit_or(self) -> None:
+        assert F.bit_or(col("m")).to_sql() == 'BIT_OR("m")'
+
+
+class TestAggregateFilter:
+    def test_filter(self) -> None:
+        expr = F.sum(col("amt")).filter(col("status") == "paid")
+        assert expr.to_sql() == """SUM("amt") FILTER (WHERE ("status" = 'paid'))"""
+
+    def test_filter_preserves_distinct(self) -> None:
+        expr = F.count_distinct(col("u")).filter(col("active"))
+        assert expr.to_sql() == 'COUNT(DISTINCT "u") FILTER (WHERE "active")'
+
+
+class TestConditional:
+    def test_greatest(self) -> None:
+        assert F.greatest(col("a"), col("b")).to_sql() == 'GREATEST("a", "b")'
+
+    def test_least(self) -> None:
+        assert F.least(col("a"), col("b"), 0).to_sql() == 'LEAST("a", "b", 0)'
+
+    def test_greatest_requires_arg(self) -> None:
+        with pytest.raises(ValueError, match="at least one"):
+            F.greatest()
 
 
 class TestMath:
@@ -65,6 +115,19 @@ class TestDateTime:
     def test_current_date(self) -> None:
         assert F.current_date().to_sql() == "CURRENT_DATE()"
 
+    def test_interval(self) -> None:
+        assert F.interval("1 day").to_sql() == "INTERVAL '1 day'"
+
+    def test_date_bin(self) -> None:
+        assert F.date_bin("1 hour", col("ts")).to_sql() == (
+            """DATE_BIN(INTERVAL '1 hour', "ts")"""
+        )
+
+    def test_date_bin_with_origin(self) -> None:
+        assert F.date_bin("1 day", col("ts"), col("origin")).to_sql() == (
+            """DATE_BIN(INTERVAL '1 day', "ts", "origin")"""
+        )
+
 
 class TestNullHandling:
     def test_coalesce(self) -> None:
@@ -88,3 +151,38 @@ class TestWindowFunctions:
 
     def test_lag_with_default(self) -> None:
         assert F.lag(col("x"), 2, 0).over().to_sql() == 'LAG("x", 2, 0) OVER ()'
+
+    def test_ntile(self) -> None:
+        assert (
+            F.ntile(4).over(order_by=[col("x")]).to_sql()
+            == 'NTILE(4) OVER (ORDER BY "x")'
+        )
+
+    def test_over_with_frame(self) -> None:
+        sql = (
+            F.sum(col("v"))
+            .over(
+                order_by=[col("ts")],
+                frame=WindowFrame("rows", None, 0),
+            )
+            .to_sql()
+        )
+        assert sql == (
+            'SUM("v") OVER (ORDER BY "ts" '
+            "ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)"
+        )
+
+    def test_partition_order_and_frame(self) -> None:
+        sql = (
+            F.avg(col("v"))
+            .over(
+                partition_by=[col("sensor")],
+                order_by=[col("ts")],
+                frame=WindowFrame("rows", 6, 0),
+            )
+            .to_sql()
+        )
+        assert sql == (
+            'AVG("v") OVER (PARTITION BY "sensor" ORDER BY "ts" '
+            "ROWS BETWEEN 6 PRECEDING AND CURRENT ROW)"
+        )


### PR DESCRIPTION
## Summary

First PR in a series adding the highest-value DataFrame / Expr / functions capabilities that were **not previously expressible** in the SDK's DataFrame layer (added in #151): windowed running aggregates, percentiles, time-series bucketing, and `LIKE` filtering.

Every addition here is **pure client-side SQL generation** — no new transport, no runtime dependency — and each is covered by the existing `to_sql()` string-composition test pattern.

## What's added

**Expr DSL** (`_expr.py`)
- `like` / `ilike` / `not_like` / `not_ilike` — the most common string filter, previously absent
- `try_cast` — non-throwing cast
- `WindowFrame(units, start, end)` (`ROWS`/`RANGE`/`GROUPS BETWEEN`) via `Expr.over(frame=...)` — unlocks running totals & moving averages, which the old frame-less `over()` could not express
- aggregate `FILTER (WHERE ...)` via `.filter()` — e.g. `F.sum(col("amt")).filter(col("status") == "paid")`

**functions** (`functions.py`)
- `date_bin` + `interval` — time-series bucketing/downsampling
- analytics aggregates: `approx_percentile_cont`, `approx_median`, `stddev_pop/samp`, `var_pop/samp`, `corr`, `covar_pop/samp`, `string_agg`, `bool_and/or`, `bit_and/or/xor`
- `greatest` / `least`
- `ntile`

**SpiceDataFrame** (`_dataframe.py`)
- `write_parquet` / `write_csv` / `write_json` delegators to the existing `Client` writers

`WindowFrame` is exported from the package top level.

## Also included

- **CI fix**: unpin `mypy` `python_version` so the type-check job stops failing on the 3.12/3.13/3.14 runners. Recent numpy stubs use PEP 695 `type` statements (3.12+ syntax) that mypy rejected under a hardcoded `python_version = "3.11"`. This was surfacing on this PR because the lint workflow hadn't run on `trunk` since May; it is unrelated to the feature changes. Verified green on mypy across 3.11–3.14 with the latest numpy.

## Example

```python
from spicepy import col, WindowFrame
from spicepy import functions as F

# 7-row trailing moving average per sensor
df.with_column(
    "avg_7",
    F.avg(col("v")).over(
        partition_by=[col("sensor")],
        order_by=[col("ts")],
        frame=WindowFrame("rows", 6, 0),
    ),
)

# p95 latency + revenue from paid orders only
df.group_by(col("region")).aggregate(
    F.approx_percentile_cont(col("latency_ms"), 0.95).alias("p95"),
    F.sum(col("amount")).filter(col("status") == "paid").alias("paid_revenue"),
)

# hourly buckets
df.group_by(F.date_bin("1 hour", col("ts")).alias("hour")).aggregate(
    F.count().alias("n")
)
```

## Testing

- New SQL-composition tests in `test_expr.py`, `test_functions.py`, `test_dataframe.py`
- Full non-runtime gate green: **334 passed**, ruff ✓, flake8 ✓, black ✓, mypy ✓ (3.11–3.14), pylint 9.31/10, bandit 0 issues
- The only failures locally are the `test_main.py` integration tests, which require a live `spiced` runtime (CI's integration job starts one; the unit job `--ignore`s that file)

## Follow-ups (not in this PR)

- Array/list + vector-distance functions (needs array/struct literal rendering)
- `_repr_html_` notebook rendering and `__arrow_c_stream__` interop
- `unnest`, statistical `describe()`, `join_on`
- Scalable local-data ingestion via Flight `do_put` (needs runtime support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)