### PR TITLE
feat: array & struct support + DataFrame unnest / joins / describe

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,9 +84,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl https://install.spiceai.org | /bin/bash
+          # The installer download/extract flakes intermittently on CI runners,
+          # so retry the two network steps before giving up (-f fails on HTTP errors).
+          retry() {
+            local n=1
+            until "$@"; do
+              [ $n -ge 3 ] && { echo "'$*' failed after $n attempts" >&2; return 1; }
+              echo "attempt $n of '$*' failed; retrying in 5s..." >&2
+              n=$((n + 1)); sleep 5
+            done
+          }
+          retry bash -c 'curl -fsSL https://install.spiceai.org | bash'
           echo "$HOME/.spice/bin" >> $GITHUB_PATH
-          $HOME/.spice/bin/spice install
+          retry "$HOME/.spice/bin/spice" install
 
       # Spice on Windows is only supported via WSL. Set up Ubuntu under WSL
       # and install Spice there; the tests on the Windows host then talk to
@@ -107,8 +117,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl https://install.spiceai.org | /bin/bash
-          $HOME/.spice/bin/spice install
+          # Retry the install: the download/extract flakes intermittently in WSL
+          # ("Failed to extract archive"). -f makes curl fail on HTTP errors.
+          retry() {
+            local n=1
+            until "$@"; do
+              [ $n -ge 3 ] && { echo "'$*' failed after $n attempts" >&2; return 1; }
+              echo "attempt $n of '$*' failed; retrying in 5s..." >&2
+              n=$((n + 1)); sleep 5
+            done
+          }
+          retry bash -c 'curl -fsSL https://install.spiceai.org | bash'
+          retry "$HOME/.spice/bin/spice" install
 
       - name: Init and start spice app
         if: matrix.os != 'windows-latest'

--- a/spicepy/_dataframe.py
+++ b/spicepy/_dataframe.py
@@ -164,6 +164,19 @@ class SpiceDataFrame:
     def distinct(self) -> SpiceDataFrame:
         return self._wrap(f"SELECT DISTINCT * FROM {self._from()}")
 
+    def unnest(self, *columns: str) -> SpiceDataFrame:
+        """Explode array column(s) into one row per element.
+
+        Non-unnested columns repeat for each element (DataFusion evaluates
+        ``unnest`` in the projection).
+        """
+        if not columns:
+            raise ValueError("unnest() requires at least one column")
+        replacements = ", ".join(
+            f"unnest({quote_ident(c)}) AS {quote_ident(c)}" for c in columns
+        )
+        return self._wrap(f"SELECT * REPLACE ({replacements}) FROM {self._from()}")
+
     # ------------------------------------------------------------------
     # Set operations
     # ------------------------------------------------------------------
@@ -185,8 +198,11 @@ class SpiceDataFrame:
     def join(
         self,
         other: SpiceDataFrame,
-        on: str | list[str] | Expr,
+        on: str | list[str] | Expr | None = None,
         how: str = "inner",
+        *,
+        left_on: str | list[str] | None = None,
+        right_on: str | list[str] | None = None,
         left_alias: str = "l",
         right_alias: str = "r",
     ) -> SpiceDataFrame:
@@ -203,7 +219,27 @@ class SpiceDataFrame:
         if kind == "cross":
             return self._wrap(f"SELECT * FROM {left} {join_sql} {right}")
 
-        if isinstance(on, Expr):
+        if left_on is not None or right_on is not None:
+            if on is not None:
+                raise ValueError("pass either `on` or `left_on`/`right_on`, not both")
+            if left_on is None or right_on is None:
+                raise ValueError("left_on and right_on must be provided together")
+            left_keys = [left_on] if isinstance(left_on, str) else list(left_on)
+            right_keys = [right_on] if isinstance(right_on, str) else list(right_on)
+            if not left_keys or len(left_keys) != len(right_keys):
+                raise ValueError(
+                    "left_on and right_on must have the same non-zero length"
+                )
+            on_sql = "ON " + " AND ".join(
+                f"{quote_ident(left_alias)}.{quote_ident(lk)} = "
+                f"{quote_ident(right_alias)}.{quote_ident(rk)}"
+                for lk, rk in zip(left_keys, right_keys, strict=True)
+            )
+        elif on is None:
+            raise ValueError(
+                "join requires `on`, or `left_on`/`right_on`, or how='cross'"
+            )
+        elif isinstance(on, Expr):
             on_sql = f"ON {on.to_sql()}"
         else:
             keys = [on] if isinstance(on, str) else list(on)
@@ -214,6 +250,32 @@ class SpiceDataFrame:
                 f"{quote_ident(right_alias)}.{quote_ident(k)}"
                 for k in keys
             )
+        return self._wrap(f"SELECT * FROM {left} {join_sql} {right} {on_sql}")
+
+    def join_on(
+        self,
+        other: SpiceDataFrame,
+        *predicates: Expr,
+        how: str = "inner",
+        left_alias: str = "l",
+        right_alias: str = "r",
+    ) -> SpiceDataFrame:
+        """Join on arbitrary boolean predicates, ANDed together.
+
+        Reference each side with a column qualifier, e.g.::
+
+            df.join_on(other, col("user_id", "l") == col("id", "r"))
+        """
+        if not predicates:
+            raise ValueError("join_on() requires at least one predicate")
+        kind = how.lower()
+        if kind not in _JOIN_KINDS or kind == "cross":
+            valid = sorted(k for k in _JOIN_KINDS if k != "cross")
+            raise ValueError(f"join_on does not support how={how!r}; expected {valid}")
+        join_sql = _JOIN_KINDS[kind]
+        left = f"{self._from()} {quote_ident(left_alias)}"
+        right = f"{other._from()} {quote_ident(right_alias)}"
+        on_sql = "ON " + " AND ".join(p.to_sql() for p in predicates)
         return self._wrap(f"SELECT * FROM {left} {join_sql} {right} {on_sql}")
 
     def cross_join(self, other: SpiceDataFrame) -> SpiceDataFrame:
@@ -239,6 +301,44 @@ class SpiceDataFrame:
         """Return the Arrow schema of this DataFrame (executes ``LIMIT 0``)."""
         reader = self._client.query(f"SELECT * FROM {self._from()} LIMIT 0")
         return reader.read_all().schema
+
+    def describe(self) -> SpiceDataFrame:
+        """Summary statistics (count, mean, stddev, min, max) per numeric column.
+
+        Reads the schema (a ``LIMIT 0`` round-trip), then returns a lazy
+        DataFrame whose rows are labelled by a ``statistic`` column. Only
+        numeric columns are summarized, matching ``pandas.DataFrame.describe``.
+        """
+        import pyarrow as pa
+
+        numeric = [
+            field.name
+            for field in self.schema()
+            if pa.types.is_integer(field.type)
+            or pa.types.is_floating(field.type)
+            or pa.types.is_decimal(field.type)
+        ]
+        if not numeric:
+            raise ValueError("describe() found no numeric columns to summarize")
+
+        stats = [
+            ("count", "CAST(COUNT({c}) AS DOUBLE)"),
+            ("mean", "AVG(CAST({c} AS DOUBLE))"),
+            ("stddev", "STDDEV(CAST({c} AS DOUBLE))"),
+            ("min", "CAST(MIN({c}) AS DOUBLE)"),
+            ("max", "CAST(MAX({c}) AS DOUBLE)"),
+        ]
+        selects = []
+        for stat_name, template in stats:
+            cols = ", ".join(
+                f"{template.format(c=quote_ident(c))} AS {quote_ident(c)}"
+                for c in numeric
+            )
+            selects.append(
+                f"SELECT {quote_literal(stat_name)} AS {quote_ident('statistic')}, "
+                f"{cols} FROM {self._from()}"
+            )
+        return self._wrap(" UNION ALL ".join(selects))
 
     def explain(self, analyze: bool = False, verbose: bool = False) -> str:
         prefix = "EXPLAIN"

--- a/spicepy/_expr.py
+++ b/spicepy/_expr.py
@@ -150,12 +150,20 @@ class Expr:
 
         Array indexing follows Python's 0-based convention and compiles to
         DataFusion's 1-based ``array_element`` — so ``col("a")[0]`` is the first
-        element. Struct fields compile to ``get_field``. For slicing, use
+        element. Negative indices are rejected (the 0-based → 1-based mapping
+        cannot express from-the-end access); use
+        :func:`spicepy.functions.array_element` with an explicit SQL index if you
+        need it. Struct fields compile to ``get_field``. For slicing, use
         :func:`spicepy.functions.array_slice`.
         """
         if isinstance(key, bool):
             raise TypeError("index must be int or str, not bool")
         if isinstance(key, int):
+            if key < 0:
+                raise ValueError(
+                    "negative array indices are not supported; use a non-negative "
+                    "0-based index, or F.array_element() with an explicit SQL index"
+                )
             return _Func("ARRAY_ELEMENT", [self, _Literal(key + 1)])
         if isinstance(key, str):
             return _Func("GET_FIELD", [self, _Literal(key)])

--- a/spicepy/_expr.py
+++ b/spicepy/_expr.py
@@ -160,7 +160,7 @@ class Expr:
             raise TypeError("index must be int or str, not bool")
         if isinstance(key, int):
             if key < 0:
-                raise ValueError(
+                raise IndexError(
                     "negative array indices are not supported; use a non-negative "
                     "0-based index, or F.array_element() with an explicit SQL index"
                 )

--- a/spicepy/_expr.py
+++ b/spicepy/_expr.py
@@ -143,6 +143,27 @@ class Expr:
     def not_ilike(self, pattern: Any) -> Expr:
         return _BinOp(self, "NOT ILIKE", _coerce(pattern))
 
+    # --- element / field access ---
+
+    def __getitem__(self, key: Any) -> Expr:
+        """Access an array element (0-indexed ``int``) or struct field (``str``).
+
+        Array indexing follows Python's 0-based convention and compiles to
+        DataFusion's 1-based ``array_element`` — so ``col("a")[0]`` is the first
+        element. Struct fields compile to ``get_field``. For slicing, use
+        :func:`spicepy.functions.array_slice`.
+        """
+        if isinstance(key, bool):
+            raise TypeError("index must be int or str, not bool")
+        if isinstance(key, int):
+            return _Func("ARRAY_ELEMENT", [self, _Literal(key + 1)])
+        if isinstance(key, str):
+            return _Func("GET_FIELD", [self, _Literal(key)])
+        raise TypeError(
+            "index must be int (array element) or str (struct field), "
+            f"got {type(key).__name__}"
+        )
+
     # --- sort qualifier (used inside sort()/order_by) ---
 
     def asc(self, nulls_first: bool = False) -> _SortExpr:

--- a/spicepy/_sql.py
+++ b/spicepy/_sql.py
@@ -43,6 +43,14 @@ def quote_literal(value: Any) -> str:
         return "CAST('" + value.isoformat() + "' AS DATE)"
     if isinstance(value, time):
         return "CAST('" + value.isoformat() + "' AS TIME)"
+    if isinstance(value, list):
+        return "MAKE_ARRAY(" + ", ".join(quote_literal(v) for v in value) + ")"
+    if isinstance(value, dict):
+        parts: list[str] = []
+        for key, item in value.items():
+            parts.append(quote_literal(str(key)))
+            parts.append(quote_literal(item))
+        return "NAMED_STRUCT(" + ", ".join(parts) + ")"
     raise TypeError(
         f"Cannot render {type(value).__name__} as a SQL literal; "
         "use a parameterized query."

--- a/spicepy/_sql.py
+++ b/spicepy/_sql.py
@@ -23,7 +23,9 @@ def quote_qualified(*parts: str) -> str:
 def quote_literal(value: Any) -> str:
     """Render a Python value as a SQL literal.
 
-    Supports None, bool, int, float, Decimal, str, bytes, date, datetime, time.
+    Supports None, bool, int, float, Decimal, str, bytes, date, datetime, time,
+    list (rendered as ``MAKE_ARRAY(...)``), and dict (rendered as
+    ``NAMED_STRUCT(...)``); lists and dicts render their items recursively.
     Raises TypeError for unsupported types — use parameterized queries instead.
     """
     if value is None:

--- a/spicepy/functions.py
+++ b/spicepy/functions.py
@@ -308,6 +308,147 @@ def case() -> _Case:
     return _case_builder()
 
 
+# --- arrays ---
+
+
+def make_array(*exprs: Any) -> Expr:
+    """Construct an array from the given elements: ``make_array(1, 2, 3)``."""
+    return _fn("MAKE_ARRAY", *exprs)
+
+
+def array(*exprs: Any) -> Expr:
+    """Alias for :func:`make_array`."""
+    return make_array(*exprs)
+
+
+def array_element(array: Any, n: Any) -> Expr:
+    """Element at 1-based index ``n`` (SQL convention). See also ``expr[i]``."""
+    return _fn("ARRAY_ELEMENT", array, n)
+
+
+def array_length(array: Any, dimension: Any = None) -> Expr:
+    if dimension is None:
+        return _fn("ARRAY_LENGTH", array)
+    return _fn("ARRAY_LENGTH", array, dimension)
+
+
+def array_append(array: Any, element: Any) -> Expr:
+    return _fn("ARRAY_APPEND", array, element)
+
+
+def array_prepend(element: Any, array: Any) -> Expr:
+    return _fn("ARRAY_PREPEND", element, array)
+
+
+def array_concat(*arrays: Any) -> Expr:
+    return _fn("ARRAY_CONCAT", *arrays)
+
+
+def array_has(array: Any, element: Any) -> Expr:
+    """True if ``array`` contains ``element``."""
+    return _fn("ARRAY_HAS", array, element)
+
+
+def array_has_all(array: Any, sub_array: Any) -> Expr:
+    return _fn("ARRAY_HAS_ALL", array, sub_array)
+
+
+def array_has_any(array: Any, other: Any) -> Expr:
+    return _fn("ARRAY_HAS_ANY", array, other)
+
+
+def array_position(array: Any, element: Any) -> Expr:
+    return _fn("ARRAY_POSITION", array, element)
+
+
+def array_slice(array: Any, begin: Any, end: Any, stride: Any = None) -> Expr:
+    """Slice with 1-based inclusive bounds (SQL convention)."""
+    if stride is None:
+        return _fn("ARRAY_SLICE", array, begin, end)
+    return _fn("ARRAY_SLICE", array, begin, end, stride)
+
+
+def array_distinct(array: Any) -> Expr:
+    return _fn("ARRAY_DISTINCT", array)
+
+
+def array_remove(array: Any, element: Any) -> Expr:
+    return _fn("ARRAY_REMOVE", array, element)
+
+
+def array_to_string(array: Any, delimiter: Any) -> Expr:
+    return _fn("ARRAY_TO_STRING", array, delimiter)
+
+
+def string_to_array(string: Any, delimiter: Any) -> Expr:
+    return _fn("STRING_TO_ARRAY", string, delimiter)
+
+
+def array_reverse(array: Any) -> Expr:
+    return _fn("ARRAY_REVERSE", array)
+
+
+def array_sort(array: Any) -> Expr:
+    return _fn("ARRAY_SORT", array)
+
+
+def array_dims(array: Any) -> Expr:
+    return _fn("ARRAY_DIMS", array)
+
+
+def array_union(a: Any, b: Any) -> Expr:
+    return _fn("ARRAY_UNION", a, b)
+
+
+def array_intersect(a: Any, b: Any) -> Expr:
+    return _fn("ARRAY_INTERSECT", a, b)
+
+
+def array_except(a: Any, b: Any) -> Expr:
+    return _fn("ARRAY_EXCEPT", a, b)
+
+
+def array_repeat(element: Any, count: Any) -> Expr:
+    return _fn("ARRAY_REPEAT", element, count)
+
+
+def array_distance(a: Any, b: Any) -> Expr:
+    """Euclidean (L2) distance between two equal-length numeric arrays."""
+    return _fn("ARRAY_DISTANCE", a, b)
+
+
+def flatten(array: Any) -> Expr:
+    return _fn("FLATTEN", array)
+
+
+def cardinality(array: Any) -> Expr:
+    return _fn("CARDINALITY", array)
+
+
+# --- structs ---
+
+
+def struct(*exprs: Any) -> Expr:
+    """Construct an unnamed struct from the given values."""
+    return _fn("STRUCT", *exprs)
+
+
+def named_struct(**fields: Any) -> Expr:
+    """Construct a struct with named fields: ``named_struct(x=1, y=2)``."""
+    if not fields:
+        raise ValueError("named_struct requires at least one field")
+    args: list[Any] = []
+    for name, value in fields.items():
+        args.append(name)
+        args.append(value)
+    return _fn("NAMED_STRUCT", *args)
+
+
+def get_field(expr: Any, name: Any) -> Expr:
+    """Extract a struct/map field by name. ``col("s")["x"]`` is shorthand."""
+    return _fn("GET_FIELD", expr, name)
+
+
 # --- window-only functions ---
 
 

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -254,6 +254,113 @@ class TestValuesDataFrame:
             values_dataframe(client, [{"a": 1}, {"b": 2}])
 
 
+class TestUnnest:
+    def test_unnest_single(self, df: SpiceDataFrame) -> None:
+        assert df.unnest("tags").to_sql() == (
+            'SELECT * REPLACE (unnest("tags") AS "tags") FROM (SELECT * FROM "trips")'
+        )
+
+    def test_unnest_multiple(self, df: SpiceDataFrame) -> None:
+        sql = df.unnest("a", "b").to_sql()
+        assert 'unnest("a") AS "a", unnest("b") AS "b"' in sql
+
+    def test_unnest_empty_raises(self, df: SpiceDataFrame) -> None:
+        with pytest.raises(ValueError, match="at least one column"):
+            df.unnest()
+
+
+class TestJoinAdvanced:
+    @pytest.fixture
+    def other(self, client: MagicMock) -> SpiceDataFrame:
+        return SpiceDataFrame(client, 'SELECT * FROM "users"')
+
+    def test_left_on_right_on(self, df: SpiceDataFrame, other: SpiceDataFrame) -> None:
+        sql = df.join(other, left_on="user_id", right_on="id").to_sql()
+        assert '"l"."user_id" = "r"."id"' in sql
+        assert "INNER JOIN" in sql
+
+    def test_left_on_right_on_multi(
+        self, df: SpiceDataFrame, other: SpiceDataFrame
+    ) -> None:
+        sql = df.join(other, left_on=["a", "b"], right_on=["x", "y"]).to_sql()
+        assert '"l"."a" = "r"."x" AND "l"."b" = "r"."y"' in sql
+
+    def test_on_and_left_on_conflict(
+        self, df: SpiceDataFrame, other: SpiceDataFrame
+    ) -> None:
+        with pytest.raises(ValueError, match="not both"):
+            df.join(other, on="id", left_on="a", right_on="b")
+
+    def test_left_on_without_right_on(
+        self, df: SpiceDataFrame, other: SpiceDataFrame
+    ) -> None:
+        with pytest.raises(ValueError, match="provided together"):
+            df.join(other, left_on="a")
+
+    def test_join_missing_on_raises(
+        self, df: SpiceDataFrame, other: SpiceDataFrame
+    ) -> None:
+        with pytest.raises(ValueError, match="join requires"):
+            df.join(other)
+
+    def test_join_on_predicate(self, df: SpiceDataFrame, other: SpiceDataFrame) -> None:
+        sql = df.join_on(
+            other, col("user_id", "l") == col("id", "r"), how="left"
+        ).to_sql()
+        assert 'ON ("l"."user_id" = "r"."id")' in sql
+        assert "LEFT JOIN" in sql
+
+    def test_join_on_multiple_predicates(
+        self, df: SpiceDataFrame, other: SpiceDataFrame
+    ) -> None:
+        sql = df.join_on(
+            other,
+            col("a", "l") == col("a", "r"),
+            col("b", "l") > col("b", "r"),
+        ).to_sql()
+        assert " AND " in sql
+
+    def test_join_on_requires_predicate(
+        self, df: SpiceDataFrame, other: SpiceDataFrame
+    ) -> None:
+        with pytest.raises(ValueError, match="at least one predicate"):
+            df.join_on(other)
+
+    def test_join_on_rejects_cross(
+        self, df: SpiceDataFrame, other: SpiceDataFrame
+    ) -> None:
+        with pytest.raises(ValueError, match="does not support"):
+            df.join_on(other, col("a", "l") == col("a", "r"), how="cross")
+
+
+class TestDescribe:
+    @staticmethod
+    def _mock_schema(client: MagicMock, schema: pa.Schema) -> None:
+        reader = MagicMock()
+        reader.read_all.return_value.schema = schema
+        client.query.return_value = reader
+
+    def test_describe_numeric(self, df: SpiceDataFrame, client: MagicMock) -> None:
+        self._mock_schema(
+            client,
+            pa.schema([("a", pa.int64()), ("b", pa.float64()), ("name", pa.string())]),
+        )
+        sql = df.describe().to_sql()
+        assert "UNION ALL" in sql
+        assert "'count'" in sql and "'mean'" in sql and "'stddev'" in sql
+        assert 'AVG(CAST("a" AS DOUBLE))' in sql
+        assert 'AS "statistic"' in sql
+        # non-numeric column is excluded from the summary
+        assert '"name"' not in sql
+
+    def test_describe_no_numeric_raises(
+        self, df: SpiceDataFrame, client: MagicMock
+    ) -> None:
+        self._mock_schema(client, pa.schema([("name", pa.string())]))
+        with pytest.raises(ValueError, match="no numeric columns"):
+            df.describe()
+
+
 class TestWriters:
     def test_write_parquet_delegates(
         self, df: SpiceDataFrame, client: MagicMock

--- a/tests/test_expr.py
+++ b/tests/test_expr.py
@@ -128,7 +128,7 @@ class TestElementAccess:
         assert col("s")["city"].to_sql() == """GET_FIELD("s", 'city')"""
 
     def test_negative_index_raises(self) -> None:
-        with pytest.raises(ValueError, match="negative array indices"):
+        with pytest.raises(IndexError, match="negative array indices"):
             _ = col("arr")[-1]
 
     def test_bool_key_raises(self) -> None:

--- a/tests/test_expr.py
+++ b/tests/test_expr.py
@@ -116,6 +116,26 @@ class TestPatternMatching:
         )
 
 
+class TestElementAccess:
+    def test_array_element_zero_indexed(self) -> None:
+        # Python 0-based -> DataFusion 1-based array_element
+        assert col("arr")[0].to_sql() == 'ARRAY_ELEMENT("arr", 1)'
+
+    def test_array_element_nonzero(self) -> None:
+        assert col("arr")[2].to_sql() == 'ARRAY_ELEMENT("arr", 3)'
+
+    def test_struct_field(self) -> None:
+        assert col("s")["city"].to_sql() == """GET_FIELD("s", 'city')"""
+
+    def test_bool_key_raises(self) -> None:
+        with pytest.raises(TypeError, match="not bool"):
+            _ = col("arr")[True]
+
+    def test_float_key_raises(self) -> None:
+        with pytest.raises(TypeError, match="index must be"):
+            _ = col("arr")[1.5]
+
+
 class TestAliasAndCast:
     def test_alias(self) -> None:
         assert col("x").alias("y").to_sql() == '"x" AS "y"'

--- a/tests/test_expr.py
+++ b/tests/test_expr.py
@@ -127,6 +127,10 @@ class TestElementAccess:
     def test_struct_field(self) -> None:
         assert col("s")["city"].to_sql() == """GET_FIELD("s", 'city')"""
 
+    def test_negative_index_raises(self) -> None:
+        with pytest.raises(ValueError, match="negative array indices"):
+            _ = col("arr")[-1]
+
     def test_bool_key_raises(self) -> None:
         with pytest.raises(TypeError, match="not bool"):
             _ = col("arr")[True]

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from spicepy import WindowFrame, col
+from spicepy import WindowFrame, col, lit
 from spicepy import functions as F
 
 
@@ -139,6 +139,85 @@ class TestNullHandling:
 
     def test_nullif(self) -> None:
         assert F.nullif(col("a"), 0).to_sql() == 'NULLIF("a", 0)'
+
+
+class TestArrays:
+    def test_make_array(self) -> None:
+        assert F.make_array(1, 2, 3).to_sql() == "MAKE_ARRAY(1, 2, 3)"
+
+    def test_array_alias(self) -> None:
+        assert F.array(col("a"), col("b")).to_sql() == 'MAKE_ARRAY("a", "b")'
+
+    def test_array_element(self) -> None:
+        assert F.array_element(col("a"), 1).to_sql() == 'ARRAY_ELEMENT("a", 1)'
+
+    def test_array_length(self) -> None:
+        assert F.array_length(col("a")).to_sql() == 'ARRAY_LENGTH("a")'
+
+    def test_array_length_with_dimension(self) -> None:
+        assert F.array_length(col("a"), 1).to_sql() == 'ARRAY_LENGTH("a", 1)'
+
+    def test_array_append(self) -> None:
+        assert F.array_append(col("a"), 9).to_sql() == 'ARRAY_APPEND("a", 9)'
+
+    def test_array_prepend(self) -> None:
+        assert F.array_prepend(0, col("a")).to_sql() == 'ARRAY_PREPEND(0, "a")'
+
+    def test_array_concat(self) -> None:
+        assert F.array_concat(col("a"), col("b")).to_sql() == 'ARRAY_CONCAT("a", "b")'
+
+    def test_array_has(self) -> None:
+        assert (
+            F.array_has(col("tags"), "urgent").to_sql()
+            == """ARRAY_HAS("tags", 'urgent')"""
+        )
+
+    def test_array_slice(self) -> None:
+        assert F.array_slice(col("a"), 1, 3).to_sql() == 'ARRAY_SLICE("a", 1, 3)'
+
+    def test_array_slice_with_stride(self) -> None:
+        assert F.array_slice(col("a"), 1, 5, 2).to_sql() == 'ARRAY_SLICE("a", 1, 5, 2)'
+
+    def test_array_to_string(self) -> None:
+        assert (
+            F.array_to_string(col("a"), ",").to_sql() == """ARRAY_TO_STRING("a", ',')"""
+        )
+
+    def test_cardinality(self) -> None:
+        assert F.cardinality(col("a")).to_sql() == 'CARDINALITY("a")'
+
+    def test_flatten(self) -> None:
+        assert F.flatten(col("a")).to_sql() == 'FLATTEN("a")'
+
+    def test_array_distance(self) -> None:
+        assert (
+            F.array_distance(col("a"), col("b")).to_sql() == 'ARRAY_DISTANCE("a", "b")'
+        )
+
+    def test_array_distance_with_literal_vector(self) -> None:
+        # embeddings/vector use case: a literal list renders as MAKE_ARRAY
+        assert (
+            F.array_distance(col("embedding"), lit([0.1, 0.2])).to_sql()
+            == 'ARRAY_DISTANCE("embedding", MAKE_ARRAY(0.1, 0.2))'
+        )
+
+
+class TestStructs:
+    def test_struct(self) -> None:
+        assert F.struct(col("a"), col("b")).to_sql() == 'STRUCT("a", "b")'
+
+    def test_named_struct(self) -> None:
+        assert (
+            F.named_struct(x=col("a"), y=1).to_sql()
+            == """NAMED_STRUCT('x', "a", 'y', 1)"""
+        )
+
+    def test_named_struct_requires_field(self) -> None:
+        with pytest.raises(ValueError, match="at least one field"):
+            F.named_struct()
+
+    def test_get_field(self) -> None:
+        assert F.get_field(col("s"), "city").to_sql() == """GET_FIELD("s", 'city')"""
 
 
 class TestWindowFunctions:

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -69,6 +69,21 @@ class TestQuoteLiteral:
     def test_time(self) -> None:
         assert quote_literal(time(9, 15, 30)) == "CAST('09:15:30' AS TIME)"
 
+    def test_list_array(self) -> None:
+        assert quote_literal([1, 2, 3]) == "MAKE_ARRAY(1, 2, 3)"
+
+    def test_list_of_strings(self) -> None:
+        assert quote_literal(["a", "b"]) == "MAKE_ARRAY('a', 'b')"
+
+    def test_nested_list(self) -> None:
+        assert (
+            quote_literal([[1, 2], [3]])
+            == "MAKE_ARRAY(MAKE_ARRAY(1, 2), MAKE_ARRAY(3))"
+        )
+
+    def test_dict_struct(self) -> None:
+        assert quote_literal({"x": 1, "y": "a"}) == "NAMED_STRUCT('x', 1, 'y', 'a')"
+
     def test_unsupported_raises(self) -> None:
         with pytest.raises(TypeError, match="Cannot render"):
-            quote_literal({"a": 1})
+            quote_literal(object())


### PR DESCRIPTION
## Summary

Continues the DataFrame/Expr parity work (following #167), in two themed groups. Everything is **pure client-side SQL generation**, and every function name + indexing/SQL convention was **verified against DataFusion's documented behavior** before implementing.

### 1. Array & struct support

**Literals** (`_sql.py`) — previously `lit([...])`/`lit({...})` raised `TypeError`:
```python
lit([1, 2, 3])    # -> MAKE_ARRAY(1, 2, 3)   (renders recursively)
lit({"x": 1})     # -> NAMED_STRUCT('x', 1)
```
**Element / field access** (`Expr.__getitem__`):
```python
col("a")[0]        # -> ARRAY_ELEMENT("a", 1)   Python 0-based -> DataFusion 1-based
col("s")["field"]  # -> GET_FIELD("s", 'field')
```
**`functions`** — arrays: `make_array`/`array`, `array_element`, `array_length`, `array_append`, `array_prepend`, `array_concat`, `array_has`/`_all`/`_any`, `array_position`, `array_slice`, `array_distinct`, `array_remove`, `array_to_string`, `string_to_array`, `array_reverse`, `array_sort`, `array_dims`, `array_union`, `array_intersect`, `array_except`, `array_repeat`, `array_distance`, `flatten`, `cardinality`; structs: `struct`, `named_struct`, `get_field`.

### 2. DataFrame: unnest, richer joins, describe

- **`unnest(*columns)`** — explode array columns into rows (`SELECT * REPLACE (unnest(c) AS c)`; DataFusion evaluates `unnest` in the projection and repeats other columns)
- **`join(..., left_on=, right_on=)`** — join on differently-named keys
- **`join_on(other, *predicates, how=)`** — join on arbitrary boolean `Expr` predicates
- **`describe()`** — count/mean/stddev/min/max per numeric column (schema round-trip + `UNION ALL` labelled by a `statistic` column), matching pandas' numeric-only default

### 3. CI robustness (`ci:` commit)

An integration job flaked at the install step (`Failed to extract archive`). Wrapped the Spice CLI + runtime install in a 3-attempt retry with backoff and hardened `curl` with `-fsSL`, for both the Linux/macOS and Windows-WSL install steps.

## Examples

```python
from spicepy import col, lit
from spicepy import functions as F

# vector nearest-neighbours
(client.table("documents")
    .with_column("dist", F.array_distance(col("embedding"), lit(query_vec)))
    .sort(col("dist").asc()).limit(10))

# explode an array column, then join on differently-named keys
events = client.table("events").unnest("tags")
events.join(client.table("tag_meta"), left_on="tags", right_on="tag")

client.table("trips").describe()   # count/mean/stddev/min/max per numeric column
```

## Deliberate scoping

`array_distance` (Euclidean/L2) is included — a confirmed native DataFusion built-in. `cosine_distance`/`dot_product`/`inner_product` are **intentionally deferred**: research (incl. apache/datafusion#12475) indicates they may not be native across DataFusion versions, so emitting them risks runtime-failing SQL.

## Testing

- SQL-composition tests across `test_sql.py`, `test_expr.py`, `test_functions.py`, `test_dataframe.py` (incl. the 0→1 array-index mapping, join validation paths, and a schema-mocked `describe`)
- Full non-runtime gate green: **374 unit tests**, ruff ✓, flake8 ✓, black ✓, mypy ✓ (3.11–3.14), pylint 9.25/10, bandit 0 issues

## Follow-ups (from the audit)

- `_repr_html_` notebook rendering and `__arrow_c_stream__` interop
- `cosine_distance`/`dot_product` once verified against the target runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)