### PR TITLE
feat: notebook/Arrow interop, DataFrame ergonomics, and function breadth

### DIFF
--- a/spicepy/_dataframe.py
+++ b/spicepy/_dataframe.py
@@ -416,7 +416,7 @@ class SpiceDataFrame:
             return self.select(_col_builder(key))
         if isinstance(key, list):
             if not key:
-                raise ValueError("column selection requires at least one column")
+                raise KeyError("column selection requires at least one column")
             return self.select(*[_col_builder(k) for k in key])
         raise TypeError(
             f"index must be a column name or list of names, got {type(key).__name__}"

--- a/spicepy/_dataframe.py
+++ b/spicepy/_dataframe.py
@@ -36,6 +36,9 @@ _JOIN_KINDS = {
     "cross": "CROSS JOIN",
 }
 
+# Rows fetched to render a notebook (_repr_html_) preview.
+_HTML_PREVIEW_ROWS = 10
+
 
 def _as_expr(value: Any) -> Expr:
     if isinstance(value, Expr):
@@ -185,11 +188,13 @@ class SpiceDataFrame:
         op = "UNION ALL" if all else "UNION"
         return self._wrap(f"{self._sql} {op} {other._sql}")
 
-    def intersect(self, other: SpiceDataFrame) -> SpiceDataFrame:
-        return self._wrap(f"{self._sql} INTERSECT {other._sql}")
+    def intersect(self, other: SpiceDataFrame, all: bool = False) -> SpiceDataFrame:
+        op = "INTERSECT ALL" if all else "INTERSECT"
+        return self._wrap(f"{self._sql} {op} {other._sql}")
 
-    def except_(self, other: SpiceDataFrame) -> SpiceDataFrame:
-        return self._wrap(f"{self._sql} EXCEPT {other._sql}")
+    def except_(self, other: SpiceDataFrame, all: bool = False) -> SpiceDataFrame:
+        op = "EXCEPT ALL" if all else "EXCEPT"
+        return self._wrap(f"{self._sql} {op} {other._sql}")
 
     # ------------------------------------------------------------------
     # Joins
@@ -400,6 +405,37 @@ class SpiceDataFrame:
     def write_json(self, path: str) -> None:
         """Write this DataFrame's result to ``path`` as newline-delimited JSON."""
         self._client.write_json(self._sql, path)
+
+    # ------------------------------------------------------------------
+    # Interop / display
+    # ------------------------------------------------------------------
+
+    def __getitem__(self, key: str | list[str]) -> SpiceDataFrame:
+        """Select column(s): ``df["a"]`` or ``df[["a", "b"]]``."""
+        if isinstance(key, str):
+            return self.select(_col_builder(key))
+        if isinstance(key, list):
+            if not key:
+                raise ValueError("column selection requires at least one column")
+            return self.select(*[_col_builder(k) for k in key])
+        raise TypeError(
+            f"index must be a column name or list of names, got {type(key).__name__}"
+        )
+
+    def __arrow_c_stream__(self, requested_schema: object = None) -> object:
+        """Expose results via the Arrow C stream interface (PyCapsule protocol).
+
+        Lets Arrow-native consumers ingest a SpiceDataFrame directly — e.g.
+        ``pyarrow.table(df)``, ``polars.DataFrame(df)``, or DuckDB. The result
+        is materialized, then its Arrow C stream is handed off.
+        """
+        return self.collect().__arrow_c_stream__(requested_schema)
+
+    def _repr_html_(self) -> str:
+        """Render a preview (first rows) as an HTML table for notebooks."""
+        preview = self.limit(_HTML_PREVIEW_ROWS).to_pandas()
+        caption = f"SpiceDataFrame preview (up to {_HTML_PREVIEW_ROWS} rows)"
+        return f"{preview.to_html(index=False)}<em>{caption}</em>"
 
     def __repr__(self) -> str:
         return f"SpiceDataFrame({self._sql})"

--- a/spicepy/_dataframe.py
+++ b/spicepy/_dataframe.py
@@ -417,6 +417,8 @@ class SpiceDataFrame:
         if isinstance(key, list):
             if not key:
                 raise KeyError("column selection requires at least one column")
+            if not all(isinstance(k, str) for k in key):
+                raise TypeError("column names in a selection list must be strings")
             return self.select(*[_col_builder(k) for k in key])
         raise TypeError(
             f"index must be a column name or list of names, got {type(key).__name__}"

--- a/spicepy/functions.py
+++ b/spicepy/functions.py
@@ -183,6 +183,106 @@ def exp(expr: Any) -> Expr:
     return _fn("EXP", expr)
 
 
+def log2(expr: Any) -> Expr:
+    return _fn("LOG2", expr)
+
+
+def log10(expr: Any) -> Expr:
+    return _fn("LOG10", expr)
+
+
+def cbrt(expr: Any) -> Expr:
+    return _fn("CBRT", expr)
+
+
+def trunc(expr: Any) -> Expr:
+    return _fn("TRUNC", expr)
+
+
+def signum(expr: Any) -> Expr:
+    return _fn("SIGNUM", expr)
+
+
+def pi() -> Expr:
+    return _Func("PI", [])
+
+
+def degrees(expr: Any) -> Expr:
+    return _fn("DEGREES", expr)
+
+
+def radians(expr: Any) -> Expr:
+    return _fn("RADIANS", expr)
+
+
+def gcd(a: Any, b: Any) -> Expr:
+    return _fn("GCD", a, b)
+
+
+def lcm(a: Any, b: Any) -> Expr:
+    return _fn("LCM", a, b)
+
+
+def factorial(expr: Any) -> Expr:
+    return _fn("FACTORIAL", expr)
+
+
+def nanvl(expr: Any, replacement: Any) -> Expr:
+    return _fn("NANVL", expr, replacement)
+
+
+def isnan(expr: Any) -> Expr:
+    return _fn("ISNAN", expr)
+
+
+def iszero(expr: Any) -> Expr:
+    return _fn("ISZERO", expr)
+
+
+def sin(expr: Any) -> Expr:
+    return _fn("SIN", expr)
+
+
+def cos(expr: Any) -> Expr:
+    return _fn("COS", expr)
+
+
+def tan(expr: Any) -> Expr:
+    return _fn("TAN", expr)
+
+
+def asin(expr: Any) -> Expr:
+    return _fn("ASIN", expr)
+
+
+def acos(expr: Any) -> Expr:
+    return _fn("ACOS", expr)
+
+
+def atan(expr: Any) -> Expr:
+    return _fn("ATAN", expr)
+
+
+def atan2(y: Any, x: Any) -> Expr:
+    return _fn("ATAN2", y, x)
+
+
+def sinh(expr: Any) -> Expr:
+    return _fn("SINH", expr)
+
+
+def cosh(expr: Any) -> Expr:
+    return _fn("COSH", expr)
+
+
+def tanh(expr: Any) -> Expr:
+    return _fn("TANH", expr)
+
+
+def cot(expr: Any) -> Expr:
+    return _fn("COT", expr)
+
+
 # --- strings ---
 
 
@@ -226,6 +326,86 @@ def starts_with(expr: Any, prefix: Any) -> Expr:
 
 def ends_with(expr: Any, suffix: Any) -> Expr:
     return _fn("ENDS_WITH", expr, suffix)
+
+
+def ltrim(expr: Any) -> Expr:
+    return _fn("LTRIM", expr)
+
+
+def rtrim(expr: Any) -> Expr:
+    return _fn("RTRIM", expr)
+
+
+def btrim(expr: Any) -> Expr:
+    return _fn("BTRIM", expr)
+
+
+def lpad(expr: Any, length: Any, fill: Any = None) -> Expr:
+    if fill is None:
+        return _fn("LPAD", expr, length)
+    return _fn("LPAD", expr, length, fill)
+
+
+def rpad(expr: Any, length: Any, fill: Any = None) -> Expr:
+    if fill is None:
+        return _fn("RPAD", expr, length)
+    return _fn("RPAD", expr, length, fill)
+
+
+def initcap(expr: Any) -> Expr:
+    return _fn("INITCAP", expr)
+
+
+def left(expr: Any, n: Any) -> Expr:
+    return _fn("LEFT", expr, n)
+
+
+def right(expr: Any, n: Any) -> Expr:
+    return _fn("RIGHT", expr, n)
+
+
+def reverse(expr: Any) -> Expr:
+    return _fn("REVERSE", expr)
+
+
+def repeat(expr: Any, n: Any) -> Expr:
+    return _fn("REPEAT", expr, n)
+
+
+def translate(expr: Any, from_chars: Any, to_chars: Any) -> Expr:
+    return _fn("TRANSLATE", expr, from_chars, to_chars)
+
+
+def concat_ws(separator: Any, *exprs: Any) -> Expr:
+    return _fn("CONCAT_WS", separator, *exprs)
+
+
+def split_part(expr: Any, delimiter: Any, n: Any) -> Expr:
+    return _fn("SPLIT_PART", expr, delimiter, n)
+
+
+def strpos(expr: Any, substring: Any) -> Expr:
+    return _fn("STRPOS", expr, substring)
+
+
+def regexp_replace(
+    expr: Any, pattern: Any, replacement: Any, flags: Any = None
+) -> Expr:
+    if flags is None:
+        return _fn("REGEXP_REPLACE", expr, pattern, replacement)
+    return _fn("REGEXP_REPLACE", expr, pattern, replacement, flags)
+
+
+def ascii(expr: Any) -> Expr:
+    return _fn("ASCII", expr)
+
+
+def chr(code: Any) -> Expr:
+    return _fn("CHR", code)
+
+
+def to_hex(expr: Any) -> Expr:
+    return _fn("TO_HEX", expr)
 
 
 # --- date/time ---
@@ -274,6 +454,30 @@ def date_bin(stride: Any, source: Any, origin: Any = None) -> Expr:
     return _Func("DATE_BIN", args)
 
 
+def to_timestamp(expr: Any, *formats: Any) -> Expr:
+    return _fn("TO_TIMESTAMP", expr, *formats)
+
+
+def to_date(expr: Any, *formats: Any) -> Expr:
+    return _fn("TO_DATE", expr, *formats)
+
+
+def from_unixtime(expr: Any) -> Expr:
+    return _fn("FROM_UNIXTIME", expr)
+
+
+def to_unixtime(expr: Any) -> Expr:
+    return _fn("TO_UNIXTIME", expr)
+
+
+def make_date(year: Any, month: Any, day: Any) -> Expr:
+    return _fn("MAKE_DATE", year, month, day)
+
+
+def to_char(expr: Any, fmt: Any) -> Expr:
+    return _fn("TO_CHAR", expr, fmt)
+
+
 # --- null / control flow ---
 
 
@@ -289,6 +493,11 @@ def nullif(a: Any, b: Any) -> Expr:
 
 def ifnull(expr: Any, default: Any) -> Expr:
     return coalesce(expr, default)
+
+
+def nvl(expr: Any, default: Any) -> Expr:
+    """Return ``expr`` if not null, else ``default`` (like ``coalesce`` of two)."""
+    return _fn("NVL", expr, default)
 
 
 def greatest(*exprs: Any) -> Expr:

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pandas as pd
 import pyarrow as pa
 import pytest
 
@@ -252,6 +253,54 @@ class TestValuesDataFrame:
     def test_mismatched_columns_raises(self, client: MagicMock) -> None:
         with pytest.raises(ValueError, match="same columns"):
             values_dataframe(client, [{"a": 1}, {"b": 2}])
+
+
+class TestColumnSelection:
+    def test_getitem_single(self, df: SpiceDataFrame) -> None:
+        assert df["city"].to_sql() == 'SELECT "city" FROM (SELECT * FROM "trips")'
+
+    def test_getitem_list(self, df: SpiceDataFrame) -> None:
+        assert df[["city", "fare"]].to_sql() == (
+            'SELECT "city", "fare" FROM (SELECT * FROM "trips")'
+        )
+
+    def test_getitem_empty_list_raises(self, df: SpiceDataFrame) -> None:
+        with pytest.raises(ValueError, match="at least one column"):
+            _ = df[[]]
+
+    def test_getitem_bad_key_raises(self, df: SpiceDataFrame) -> None:
+        with pytest.raises(TypeError, match="column name or list"):
+            _ = df[5]
+
+
+class TestSetOpAll:
+    def test_intersect_all(self, df: SpiceDataFrame, client: MagicMock) -> None:
+        other = SpiceDataFrame(client, 'SELECT * FROM "t2"')
+        assert "INTERSECT ALL" in df.intersect(other, all=True).to_sql()
+
+    def test_except_all(self, df: SpiceDataFrame, client: MagicMock) -> None:
+        other = SpiceDataFrame(client, 'SELECT * FROM "t2"')
+        assert "EXCEPT ALL" in df.except_(other, all=True).to_sql()
+
+
+class TestReprHtml:
+    def test_repr_html(self, df: SpiceDataFrame, client: MagicMock) -> None:
+        client.query_pandas.return_value = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+        html = df._repr_html_()
+        assert "<table" in html
+        assert "SpiceDataFrame preview" in html
+        # the preview came from a LIMIT query
+        assert "LIMIT" in client.query_pandas.call_args[0][0]
+
+
+class TestArrowCStream:
+    def test_arrow_c_stream_roundtrips(
+        self, df: SpiceDataFrame, client: MagicMock
+    ) -> None:
+        table = pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        client.query_arrow.return_value = table
+        result = pa.RecordBatchReader.from_stream(df).read_all()
+        assert result.equals(table)
 
 
 class TestUnnest:

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -265,7 +265,7 @@ class TestColumnSelection:
         )
 
     def test_getitem_empty_list_raises(self, df: SpiceDataFrame) -> None:
-        with pytest.raises(ValueError, match="at least one column"):
+        with pytest.raises(KeyError, match="at least one column"):
             _ = df[[]]
 
     def test_getitem_bad_key_raises(self, df: SpiceDataFrame) -> None:

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -272,6 +272,10 @@ class TestColumnSelection:
         with pytest.raises(TypeError, match="column name or list"):
             _ = df[5]
 
+    def test_getitem_non_str_element_raises(self, df: SpiceDataFrame) -> None:
+        with pytest.raises(TypeError, match="must be strings"):
+            _ = df[["a", 1]]
+
 
 class TestSetOpAll:
     def test_intersect_all(self, df: SpiceDataFrame, client: MagicMock) -> None:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -233,6 +233,83 @@ class TestNvl:
         assert F.nvl(col("a"), 0).to_sql() == 'NVL("a", 0)'
 
 
+class TestMathCoverage:
+    @pytest.mark.parametrize(
+        "fn, name",
+        [
+            (F.cos, "COS"),
+            (F.tan, "TAN"),
+            (F.asin, "ASIN"),
+            (F.acos, "ACOS"),
+            (F.atan, "ATAN"),
+            (F.sinh, "SINH"),
+            (F.cosh, "COSH"),
+            (F.tanh, "TANH"),
+            (F.cot, "COT"),
+            (F.cbrt, "CBRT"),
+            (F.radians, "RADIANS"),
+            (F.factorial, "FACTORIAL"),
+            (F.isnan, "ISNAN"),
+            (F.iszero, "ISZERO"),
+        ],
+    )
+    def test_unary_math(self, fn, name: str) -> None:
+        assert fn(col("x")).to_sql() == f'{name}("x")'
+
+    def test_lcm(self) -> None:
+        assert F.lcm(col("a"), col("b")).to_sql() == 'LCM("a", "b")'
+
+    def test_nanvl(self) -> None:
+        assert F.nanvl(col("x"), 0).to_sql() == 'NANVL("x", 0)'
+
+
+class TestStringCoverage:
+    @pytest.mark.parametrize(
+        "fn, name",
+        [
+            (F.ltrim, "LTRIM"),
+            (F.rtrim, "RTRIM"),
+            (F.btrim, "BTRIM"),
+            (F.ascii, "ASCII"),
+            (F.to_hex, "TO_HEX"),
+        ],
+    )
+    def test_unary_string(self, fn, name: str) -> None:
+        assert fn(col("c")).to_sql() == f'{name}("c")'
+
+    def test_rpad_two_arg(self) -> None:
+        assert F.rpad(col("c"), 5).to_sql() == 'RPAD("c", 5)'
+
+    def test_rpad_three_arg(self) -> None:
+        assert F.rpad(col("c"), 5, "-").to_sql() == """RPAD("c", 5, '-')"""
+
+    def test_right(self) -> None:
+        assert F.right(col("c"), 3).to_sql() == 'RIGHT("c", 3)'
+
+    def test_repeat(self) -> None:
+        assert F.repeat(col("c"), 2).to_sql() == 'REPEAT("c", 2)'
+
+    def test_translate(self) -> None:
+        assert (
+            F.translate(col("c"), "abc", "xyz").to_sql()
+            == """TRANSLATE("c", 'abc', 'xyz')"""
+        )
+
+    def test_strpos(self) -> None:
+        assert F.strpos(col("c"), "x").to_sql() == """STRPOS("c", 'x')"""
+
+    def test_chr(self) -> None:
+        assert F.chr(65).to_sql() == "CHR(65)"
+
+
+class TestDateTimeCoverage:
+    def test_to_unixtime(self) -> None:
+        assert F.to_unixtime(col("ts")).to_sql() == 'TO_UNIXTIME("ts")'
+
+    def test_to_char(self) -> None:
+        assert F.to_char(col("ts"), "%Y").to_sql() == """TO_CHAR("ts", '%Y')"""
+
+
 class TestArrays:
     def test_make_array(self) -> None:
         assert F.make_array(1, 2, 3).to_sql() == "MAKE_ARRAY(1, 2, 3)"

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -141,6 +141,98 @@ class TestNullHandling:
         assert F.nullif(col("a"), 0).to_sql() == 'NULLIF("a", 0)'
 
 
+class TestMoreMath:
+    def test_log2(self) -> None:
+        assert F.log2(col("x")).to_sql() == 'LOG2("x")'
+
+    def test_log10(self) -> None:
+        assert F.log10(col("x")).to_sql() == 'LOG10("x")'
+
+    def test_trunc(self) -> None:
+        assert F.trunc(col("x")).to_sql() == 'TRUNC("x")'
+
+    def test_signum(self) -> None:
+        assert F.signum(col("x")).to_sql() == 'SIGNUM("x")'
+
+    def test_pi(self) -> None:
+        assert F.pi().to_sql() == "PI()"
+
+    def test_atan2(self) -> None:
+        assert F.atan2(col("y"), col("x")).to_sql() == 'ATAN2("y", "x")'
+
+    def test_gcd(self) -> None:
+        assert F.gcd(col("a"), col("b")).to_sql() == 'GCD("a", "b")'
+
+    def test_sin(self) -> None:
+        assert F.sin(col("x")).to_sql() == 'SIN("x")'
+
+    def test_degrees(self) -> None:
+        assert F.degrees(col("x")).to_sql() == 'DEGREES("x")'
+
+
+class TestMoreStrings:
+    def test_lpad_two_arg(self) -> None:
+        assert F.lpad(col("c"), 5).to_sql() == 'LPAD("c", 5)'
+
+    def test_lpad_three_arg(self) -> None:
+        assert F.lpad(col("c"), 5, "*").to_sql() == """LPAD("c", 5, '*')"""
+
+    def test_split_part(self) -> None:
+        assert F.split_part(col("c"), ",", 1).to_sql() == """SPLIT_PART("c", ',', 1)"""
+
+    def test_initcap(self) -> None:
+        assert F.initcap(col("c")).to_sql() == 'INITCAP("c")'
+
+    def test_regexp_replace(self) -> None:
+        assert (
+            F.regexp_replace(col("c"), "a", "b").to_sql()
+            == """REGEXP_REPLACE("c", 'a', 'b')"""
+        )
+
+    def test_regexp_replace_with_flags(self) -> None:
+        assert (
+            F.regexp_replace(col("c"), "a", "b", "g").to_sql()
+            == """REGEXP_REPLACE("c", 'a', 'b', 'g')"""
+        )
+
+    def test_reverse(self) -> None:
+        assert F.reverse(col("c")).to_sql() == 'REVERSE("c")'
+
+    def test_concat_ws(self) -> None:
+        assert (
+            F.concat_ws("-", col("a"), col("b")).to_sql()
+            == """CONCAT_WS('-', "a", "b")"""
+        )
+
+    def test_left(self) -> None:
+        assert F.left(col("c"), 3).to_sql() == 'LEFT("c", 3)'
+
+
+class TestMoreDateTime:
+    def test_to_timestamp(self) -> None:
+        assert F.to_timestamp(col("s")).to_sql() == 'TO_TIMESTAMP("s")'
+
+    def test_to_timestamp_with_format(self) -> None:
+        assert (
+            F.to_timestamp(col("s"), "%Y-%m-%d").to_sql()
+            == """TO_TIMESTAMP("s", '%Y-%m-%d')"""
+        )
+
+    def test_to_date(self) -> None:
+        assert F.to_date(col("s")).to_sql() == 'TO_DATE("s")'
+
+    def test_from_unixtime(self) -> None:
+        assert F.from_unixtime(col("ts")).to_sql() == 'FROM_UNIXTIME("ts")'
+
+    def test_make_date(self) -> None:
+        assert F.make_date(2024, 1, 15).to_sql() == "MAKE_DATE(2024, 1, 15)"
+
+
+class TestNvl:
+    def test_nvl(self) -> None:
+        assert F.nvl(col("a"), 0).to_sql() == 'NVL("a", 0)'
+
+
 class TestArrays:
     def test_make_array(self) -> None:
         assert F.make_array(1, 2, 3).to_sql() == "MAKE_ARRAY(1, 2, 3)"


### PR DESCRIPTION
## Summary

Completes the **remaining pure-SQL-client items** from the DataFusion parity audit (following #167 and #168), in one PR. All function names were verified against DataFusion's documented function set before implementing.

## Interop / display (the headline)

- **`_repr_html_`** — a SpiceDataFrame now renders a preview (first rows) as an HTML table in Jupyter/notebooks
- **`__arrow_c_stream__`** — exposes results via the Arrow C stream (PyCapsule) protocol, so Arrow-native consumers ingest a SpiceDataFrame directly:
  ```python
  pa.table(df)            # or pa.RecordBatchReader.from_stream(df)
  pl.DataFrame(df)        # polars
  duckdb.sql("SELECT * FROM df")
  ```
- **`df["a"]` / `df[["a", "b"]]`** — column selection via `__getitem__`
- **`intersect(other, all=True)` / `except_(other, all=True)`** — `INTERSECT ALL` / `EXCEPT ALL`

## Function breadth (`functions`)

- **math**: `sin/cos/tan/asin/acos/atan/atan2`, `sinh/cosh/tanh/cot`, `log2`, `log10`, `cbrt`, `trunc`, `signum`, `pi`, `degrees`, `radians`, `gcd`, `lcm`, `factorial`, `nanvl`, `isnan`, `iszero`
- **strings**: `ltrim/rtrim/btrim`, `lpad`, `rpad`, `initcap`, `left`, `right`, `reverse`, `repeat`, `translate`, `concat_ws`, `split_part`, `strpos`, `regexp_replace`, `ascii`, `chr`, `to_hex`
- **date/time**: `to_timestamp`, `to_date`, `from_unixtime`, `to_unixtime`, `make_date`, `to_char`
- **null**: `nvl`

## Explicitly deferred (and why)

Audit items I did **not** ship, because they can't be done correctly from the client alone or I couldn't verify them against a runtime — shipping them would risk runtime-failing SQL or dead code:

- **Flight `do_put` local-data ingestion** — the biggest *functional* gap (today `from_pandas` inlines rows as `VALUES`), but it needs the **Spice runtime** to accept an uploaded ephemeral table. Requires runtime-side support + a live runtime to verify. Best as its own PR with runtime coordination.
- **Async client / `execute_stream`** — a substantial transport change (async Flight); worth its own focused PR.
- **`cosine_distance` / `dot_product` / `inner_product`** — native availability isn't confirmed across DataFusion versions (see apache/datafusion#12475). `array_distance` (shipped in #168) covers L2.
- **`distinct_on` / `union_by_name`** — `DISTINCT ON` / `UNION BY NAME` support in the target runtime is unverified; deferred rather than emit uncertain SQL.

## Testing

- SQL-composition tests for every new function + the DataFrame methods (incl. an `__arrow_c_stream__` round-trip through `pa.RecordBatchReader.from_stream`, and a `_repr_html_` that asserts the preview uses a `LIMIT` query)
- Full non-runtime gate green: **407 unit tests**, ruff ✓, flake8 ✓, black ✓, mypy ✓ (3.11–3.14), pylint 9.24/10, bandit 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)