### PR TITLE
perf: stream parameterized query results instead of buffering them

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ reader = client.query_with_params(
 )
 ```
 
+The reader returned by `query_with_params` streams: batches arrive as you consume
+them, so the full result is never held in memory at once. Iterate it (as above)
+rather than calling `read_all()` when the result is large.
+
 #### Multiple Parameters
 
 ```python
@@ -113,6 +117,30 @@ reader = client.query_with_params(
 - **Null**: `pa.null()`
 
 See the [PyArrow documentation](https://arrow.apache.org/docs/python/api/datatypes.html) for the full list of available types.
+
+### Large Result Sets
+
+`query_arrow`, `query_pandas`, `query_polars`, `query_pylist` and `query_pydict`
+materialize the whole result in memory. For results too large to hold at once,
+use `query_batches`, which yields Arrow `RecordBatch`es as they stream in and
+keeps memory bounded by the in-flight batches rather than the result size:
+
+```python
+from spicepy import Client
+
+client = Client()
+
+total = 0
+for batch in client.query_batches('SELECT * FROM taxi_trips'):
+    total += batch.num_rows
+
+# Parameterized queries stream too
+for batch in client.query_batches(
+    'SELECT * FROM taxi_trips WHERE trip_distance > $1',
+    params=[5.0],
+):
+    total += batch.num_rows
+```
 
 Querying data is done through a `Client` object that initialize the connection with Spice endpoint. `Client` has the following arguments:
 

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -58,6 +58,28 @@ except (ImportError, ModuleNotFoundError):
 DEFAULT_QUERY_TIMEOUT_SECS = 10 * 60
 
 
+def _stream_until_closed(
+    reader: pa.RecordBatchReader,
+    stmt: Any,
+) -> pa.RecordBatchReader:
+    """Return a reader that streams ``reader`` and closes ``stmt`` when done.
+
+    The ADBC statement owns the result stream, so it must stay open for as long
+    as the caller is reading. It is released when the stream is exhausted, or
+    when the returned reader is closed or garbage collected.
+    """
+    schema = reader.schema
+
+    def batches() -> Iterator[pa.RecordBatch]:
+        try:
+            yield from reader
+        finally:
+            reader.close()
+            stmt.close()
+
+    return pa.RecordBatchReader.from_batches(schema, batches())
+
+
 class _ADBCClient:
     """ADBC client for parameterized queries using FlightSQL."""
 
@@ -161,7 +183,9 @@ class _ADBCClient:
                 - A tuple of (value, pyarrow.DataType) for explicit type control
 
         Returns:
-            Arrow RecordBatchReader with query results
+            Arrow RecordBatchReader that streams query results. Batches are
+            fetched from the server as they are consumed, so the full result
+            is never held in memory unless the caller materializes it.
         """
         # Create a new statement
         stmt = adbc_driver_manager.AdbcStatement(self._conn)
@@ -182,14 +206,16 @@ class _ADBCClient:
 
             # Execute and get results
             handle, _ = stmt.execute_query()
-
-            # Read results into Arrow table using from_stream
             reader = pa.RecordBatchReader.from_stream(handle)
-            # Consume reader into table, then return a new reader
-            table = reader.read_all()
-            return table.to_reader()
-        finally:
+        except BaseException:
             stmt.close()
+            raise
+
+        # The statement has to outlive the result stream, so it is closed once
+        # the stream is drained (or when the caller closes/abandons the reader)
+        # instead of here. Closing it up front would force the whole result to
+        # be buffered before this call could return.
+        return _stream_until_closed(reader, stmt)
 
     def close(self):
         """Close the ADBC connection."""

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -592,13 +592,20 @@ class Client:
         self,
         sql: str,
         *,
+        params: list[Any] | None = None,
         timeout: int | None = None,
     ) -> Iterator[pa.RecordBatch]:
         """Execute a SQL query and yield Arrow RecordBatches as they stream in.
 
         Unlike :meth:`query_arrow`, this does not materialize the full result
-        in memory before returning.
+        in memory before returning, which makes it the right choice for result
+        sets too large to hold in memory.
+
+        See :meth:`query_arrow` for argument semantics.
         """
+        if params is not None:
+            yield from self.query_with_params(sql, params)
+            return
         kwargs: dict[str, Any] = {}
         if timeout is not None:
             kwargs["timeout"] = timeout

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gc
 import os
 from pathlib import Path
 import threading
@@ -433,6 +434,130 @@ class TestADBCClient:
         mock_db.close.assert_called_once()
         assert client._db is None
         assert client._conn is None
+
+
+class TestADBCClientStreaming:
+    """_ADBCClient.query_with_params must stream, not buffer the whole result."""
+
+    SCHEMA = pa.schema([pa.field("a", pa.int64())])
+
+    @staticmethod
+    def _adbc_client(mock_manager: MagicMock, mock_flightsql: MagicMock) -> _ADBCClient:
+        mock_flightsql.connect.return_value = MagicMock()
+        mock_manager.AdbcConnection.return_value = MagicMock()
+        return _ADBCClient("grpc://localhost:50051")
+
+    @classmethod
+    def _source(cls, pulled: list[int], count: int = 3) -> pa.RecordBatchReader:
+        """A reader that records each batch as it is pulled off the wire."""
+
+        def batches() -> object:
+            for i in range(count):
+                pulled.append(i)
+                yield pa.record_batch(
+                    [pa.array([i], type=pa.int64())], schema=cls.SCHEMA
+                )
+
+        return pa.RecordBatchReader.from_batches(cls.SCHEMA, batches())
+
+    @pytest.mark.skipif(not ADBC_AVAILABLE, reason="ADBC not installed")
+    @patch("spicepy._client.adbc_driver_flightsql")
+    @patch("spicepy._client.adbc_driver_manager")
+    def test_query_with_params_does_not_buffer_result(
+        self,
+        mock_manager: MagicMock,
+        mock_flightsql: MagicMock,
+    ) -> None:
+        """Returning the reader must not drain the result stream first."""
+        client = self._adbc_client(mock_manager, mock_flightsql)
+        pulled: list[int] = []
+        stmt = MagicMock()
+        # A real reader stands in for the ADBC result handle; from_stream()
+        # consumes it lazily through the Arrow C stream interface.
+        stmt.execute_query.return_value = (self._source(pulled), None)
+        mock_manager.AdbcStatement.return_value = stmt
+
+        reader = client.query_with_params("SELECT * FROM t WHERE a = $1", [])
+
+        # The whole result must not have been read just to hand back a reader.
+        assert pulled != [0, 1, 2], "result was buffered instead of streamed"
+        # The statement owns the stream, so it stays open while the caller reads.
+        stmt.close.assert_not_called()
+
+        reader.read_next_batch()
+        assert pulled == [0]
+        stmt.close.assert_not_called()
+
+    @pytest.mark.skipif(not ADBC_AVAILABLE, reason="ADBC not installed")
+    @patch("spicepy._client.adbc_driver_flightsql")
+    @patch("spicepy._client.adbc_driver_manager")
+    def test_query_with_params_yields_all_batches_and_closes_statement(
+        self,
+        mock_manager: MagicMock,
+        mock_flightsql: MagicMock,
+    ) -> None:
+        """Draining the reader yields every batch, then releases the statement."""
+        client = self._adbc_client(mock_manager, mock_flightsql)
+        pulled: list[int] = []
+        stmt = MagicMock()
+        # A real reader stands in for the ADBC result handle; from_stream()
+        # consumes it lazily through the Arrow C stream interface.
+        stmt.execute_query.return_value = (self._source(pulled), None)
+        mock_manager.AdbcStatement.return_value = stmt
+
+        reader = client.query_with_params("SELECT * FROM t WHERE a = $1", [])
+
+        table = reader.read_all()
+
+        assert table.num_rows == 3
+        assert table.column("a").to_pylist() == [0, 1, 2]
+        assert pulled == [0, 1, 2]
+        stmt.close.assert_called_once()
+
+    @pytest.mark.skipif(not ADBC_AVAILABLE, reason="ADBC not installed")
+    @patch("spicepy._client.adbc_driver_flightsql")
+    @patch("spicepy._client.adbc_driver_manager")
+    def test_query_with_params_closes_statement_on_error(
+        self,
+        mock_manager: MagicMock,
+        mock_flightsql: MagicMock,
+    ) -> None:
+        """A failure before the stream exists must still release the statement."""
+        client = self._adbc_client(mock_manager, mock_flightsql)
+        stmt = MagicMock()
+        stmt.execute_query.side_effect = RuntimeError("boom")
+        mock_manager.AdbcStatement.return_value = stmt
+
+        with pytest.raises(RuntimeError, match="boom"):
+            client.query_with_params("SELECT * FROM t WHERE a = $1", [])
+
+        stmt.close.assert_called_once()
+
+    @pytest.mark.skipif(not ADBC_AVAILABLE, reason="ADBC not installed")
+    @patch("spicepy._client.adbc_driver_flightsql")
+    @patch("spicepy._client.adbc_driver_manager")
+    def test_query_with_params_closes_statement_when_abandoned(
+        self,
+        mock_manager: MagicMock,
+        mock_flightsql: MagicMock,
+    ) -> None:
+        """Closing the reader early must not leak the statement."""
+        client = self._adbc_client(mock_manager, mock_flightsql)
+        pulled: list[int] = []
+        stmt = MagicMock()
+        # A real reader stands in for the ADBC result handle; from_stream()
+        # consumes it lazily through the Arrow C stream interface.
+        stmt.execute_query.return_value = (self._source(pulled), None)
+        mock_manager.AdbcStatement.return_value = stmt
+
+        reader = client.query_with_params("SELECT * FROM t WHERE a = $1", [])
+
+        reader.read_next_batch()
+        reader.close()
+        del reader
+        gc.collect()
+
+        stmt.close.assert_called_once()
 
 
 class TestADBCClientCreateParamBatch:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1580,6 +1580,34 @@ class TestClientBatchesAndPydict:
         batches = list(client.query_batches("SELECT 1"))
         assert batches == [batch1, batch2]
 
+    @patch("spicepy._client._SpiceFlight")
+    @patch("spicepy._client._Cert")
+    @patch("spicepy._client._ADBCClient")
+    def test_query_batches_with_params_streams(
+        self,
+        mock_adbc_class: MagicMock,
+        mock_cert_class: MagicMock,
+        mock_flight_class: MagicMock,
+    ) -> None:
+        """Parameterized batch streaming goes through the ADBC reader."""
+        mock_cert = MagicMock()
+        mock_cert.tls_root_certs = b"cert"
+        mock_cert_class.return_value = mock_cert
+
+        batch1 = pa.record_batch({"x": [1, 2]})
+        batch2 = pa.record_batch({"x": [3, 4]})
+        mock_adbc = MagicMock()
+        mock_adbc.query_with_params.return_value = iter([batch1, batch2])
+        mock_adbc_class.return_value = mock_adbc
+
+        client = Client()
+        batches = list(client.query_batches("SELECT * FROM t WHERE x > $1", params=[0]))
+
+        assert batches == [batch1, batch2]
+        mock_adbc.query_with_params.assert_called_once_with(
+            "SELECT * FROM t WHERE x > $1", [0]
+        )
+
 
 class TestClientDataFrameEntry:
     @patch("spicepy._client._SpiceFlight")


### PR DESCRIPTION
## Problem

`Client.query_with_params()` documents that it returns a streaming `pa.RecordBatchReader`, but it materialized the whole result before returning:

```python
handle, _ = stmt.execute_query()
reader = pa.RecordBatchReader.from_stream(handle)
table = reader.read_all()      # <- entire result pulled into memory
return table.to_reader()
finally:
    stmt.close()
```

The eager read was forced by the `finally: stmt.close()`. The ADBC statement owns the result stream, so closing it there meant the stream had to be drained first.

The effect is that a parameterized query over a large table has no streaming behaviour at all: asking for the first batch pays the cost of the entire result, in both time and memory.

## Fix

Keep the statement alive until the stream is drained — or until the returned reader is closed or garbage collected — and hand back a reader that pulls batches off the wire on demand.

## Measurements

Against a local runtime serving a 10M-row (382 MiB) Arrow-accelerated table, `SELECT * FROM big WHERE id >= $1`:

| | before | after |
|---|---|---|
| time to first batch | 0.305 s | **0.021 s** |
| peak RSS while streaming the full result | 579 MB | **248 MB** |
| peak RSS, non-parameterized streaming (reference) | 157 MB | 157 MB |

Fully materializing the result (`query_arrow(sql, params=[...])`) is unchanged at ~0.22 s / ~575 MB, as expected — the win is for callers that stream.

For reference, the non-parameterized paths were already streaming correctly and are unchanged by this PR; they measure at parity with a raw `pyarrow` Flight client.

## Tests

Adds `TestADBCClientStreaming` covering that:

- the result is **not** drained before the reader is returned (this test fails on `trunk` with `result was buffered instead of streamed`)
- draining the reader yields every batch and then releases the statement
- the statement is released when the reader is closed early or abandoned
- the statement is released when execution fails

Full suite: 390 passed, 24 skipped. `ruff` reports no new findings (2 pre-existing `PLR0917`), `black` clean, `mypy` clean, `pylint` 9.26/10.

`tests/test_main.py::test_local_runtime_refresh` fails identically before and after this change — it is an integration test needing a local runtime with a `taxi_trips` dataset.

---

## Follow-up in this PR: reachable from `query_batches`, and documented

`query_batches` is the streaming entry point, but it only accepted a plain SQL
string — so the now-streaming parameterized path could not be reached through
it. It takes `params` as well:

```python
for batch in client.query_batches(
    'SELECT * FROM taxi_trips WHERE trip_distance > $1', params=[5.0]
):
    ...
```

The README now also states which `query_*` helpers materialize the whole result
and which one to reach for when it does not fit in memory — previously neither
`query_batches` nor the materializing helpers were documented at all.

### Additional measurements

Peak RSS while streaming a parameterized result is now flat in the result size
rather than proportional to it, measured against a local runtime over an
Arrow-accelerated table (isolated process per run, `ru_maxrss`):

| rows | before | after |
|---|---|---|
| 10M | 559-581 MiB | 248-250 MiB |
| 20M | 946-969 MiB | 257-265 MiB |

Time to first batch is likewise flat: 0.30 s → 0.027 s at 10M rows, 0.59 s →
0.030 s at 20M.

### Verification

Run against a local runtime with an Arrow-accelerated dataset, so the
integration tests execute rather than skip:

- `pytest` — 392 passed, 24 skipped (cloud tests, no API key)
- `mypy` — clean; `pylint` — 9.26/10
- `ruff check` — 2 findings, both pre-existing on `trunk` and untouched here
- `ruff format --check` — 15 files would be reformatted, identical before and
  after this change (the committed formatting predates the configured
  `line-length`); left alone so it does not bury the change

`tests/test_main.py::test_local_runtime_refresh` is order- and timing-dependent
against a live runtime — it truncates the shared dataset via `refresh_sql` and
races an async refresh — so it can fail on a re-run regardless of this change.
