### PR TITLE
feat: add runtime_status and is_ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,39 @@ Once a `Client` is obtained queries can be made using the `query()` function. Th
 
 A custom timeout can be set by passing the `timeout` parameter in the `query` function call. If no timeout is specified, it will default to a 10 min timeout then cancel the query, and a TimeoutError exception will be raised.
 
+### Runtime Health and Status
+
+`is_ready()` reports whether the runtime is ready to serve queries — useful for waiting
+on a runtime to come up before querying it:
+
+```python
+from spicepy import Client
+
+client = Client(http_url="http://127.0.0.1:8090")
+
+if not client.is_ready():
+    print("runtime is not ready yet")
+```
+
+When you need to know *which* component is not ready, `runtime_status()` reports each
+runtime connection separately:
+
+```python
+for component in client.runtime_status():
+    print(f"{component.name} ({component.endpoint}): {component.status}")
+
+# http (127.0.0.1:8090): Ready
+# flight (127.0.0.1:50051): Ready
+# metrics (N/A): Disabled
+# opentelemetry (127.0.0.1:50051): Ready
+```
+
+Each `ConnectionDetails` carries the component `name` (`http`, `flight`, `metrics` or
+`opentelemetry`), its `endpoint`, and its `status` — a `ComponentStatus` of
+`Initializing`, `Ready`, `Disabled`, `Error`, `Refreshing`, `ShuttingDown` or
+`NotLoaded`. `component.is_ready` is shorthand for a `Ready` status. A status added by
+a future runtime is preserved as a plain string rather than raising.
+
 ## Documentation
 
 Check out our [Documentation](https://docs.spice.ai/sdks/python-sdk) to learn more about how to use the Python SDK.

--- a/spicepy/__init__.py
+++ b/spicepy/__init__.py
@@ -10,9 +10,12 @@ from ._client import Client
 from ._dataframe import SpiceDataFrame
 from ._expr import Expr, WindowFrame, case, col, lit
 from ._http import RefreshOpts
+from ._status import ComponentStatus, ConnectionDetails
 
 __all__ = [
     "Client",
+    "ComponentStatus",
+    "ConnectionDetails",
     "Expr",
     "RefreshOpts",
     "SpiceDataFrame",

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -752,6 +752,13 @@ class Client:
                 f"components, got {type(response).__name__}."
             )
 
+        for index, item in enumerate(response):
+            if not isinstance(item, dict):
+                raise SpiceAIError(
+                    f"Unexpected response from /v1/status: expected component "
+                    f"{index} to be an object, got {type(item).__name__}."
+                )
+
         return [ConnectionDetails.from_dict(item) for item in response]
 
     def is_ready(self) -> bool:

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -24,6 +24,8 @@ from pyarrow._flight import (
 
 from . import config
 from ._http import HttpRequests, RefreshOpts
+from ._status import ConnectionDetails
+from .error import SpiceAIError
 from .params import infer_arrow_type
 
 
@@ -734,6 +736,41 @@ class Client:
         import pyarrow as pa
 
         return self.from_arrow(pa.Table.from_pydict(data))
+
+    def runtime_status(self) -> list[ConnectionDetails]:
+        """Return the status of each runtime connection.
+
+        Backed by ``GET /v1/status``. Where :meth:`is_ready` reports a single boolean
+        for the whole runtime, this reports ``http``, ``flight``, ``metrics`` and
+        ``opentelemetry`` individually, so it can say *which* component is not ready.
+        """
+        response = self.http.send_request("GET", "/v1/status")
+
+        if not isinstance(response, list):
+            raise SpiceAIError(
+                f"Unexpected response from /v1/status: expected a list of "
+                f"components, got {type(response).__name__}."
+            )
+
+        return [ConnectionDetails.from_dict(item) for item in response]
+
+    def is_ready(self) -> bool:
+        """Return whether the runtime is ready to serve queries.
+
+        Backed by ``GET /v1/ready``, which answers ``200`` when ready and ``503``
+        when not. Any other status raises :class:`SpiceAIError`, so "not ready" and
+        "could not ask" stay distinguishable.
+        """
+        response = self.http.send_request_raw("GET", "/v1/ready")
+
+        if response.status_code == 200:
+            return True
+        if response.status_code == 503:
+            return False
+
+        raise SpiceAIError(
+            f"Unexpected response from /v1/ready: HTTP {response.status_code}."
+        )
 
     def refresh_dataset(
         self, dataset: str, refresh_opts: RefreshOpts | None = None

--- a/spicepy/_http.py
+++ b/spicepy/_http.py
@@ -89,17 +89,15 @@ class HttpRequests:
         decodes JSON. Needed for endpoints whose status code carries the meaning
         (``/v1/ready`` answers ``503`` for "not ready") or whose body is not JSON.
         """
-        if headers is None:
-            headers = {}
-
-        headers.update(self.session.headers)
+        merged_headers = dict(headers) if headers is not None else {}
+        merged_headers.update(self.session.headers)
 
         return self._operation(method)(  # type: ignore[call-arg]
             url=f"{self.base_url}{path}",
             data=body,
             params=self.prepare_param(param.copy()) if param is not None else None,
             verify=True,
-            headers=headers,
+            headers=merged_headers,
         )
 
     def prepare_param(self, params: dict[str, Any]) -> dict[str, Any]:

--- a/spicepy/_http.py
+++ b/spicepy/_http.py
@@ -73,6 +73,35 @@ class HttpRequests:
         response.raise_for_status()
         return response.json()
 
+    # pylint: disable=R0913
+    # pylint: disable=R0917
+    def send_request_raw(
+        self,
+        method: HttpMethod,
+        path: str,
+        param: dict[str, Any] | None = None,
+        headers: dict[str, Any] | None = None,
+        body: str | None = None,
+    ) -> Response:
+        """Send a request and return the raw ``Response``.
+
+        Unlike :meth:`send_request`, this neither raises on a non-2xx status nor
+        decodes JSON. Needed for endpoints whose status code carries the meaning
+        (``/v1/ready`` answers ``503`` for "not ready") or whose body is not JSON.
+        """
+        if headers is None:
+            headers = {}
+
+        headers.update(self.session.headers)
+
+        return self._operation(method)(  # type: ignore[call-arg]
+            url=f"{self.base_url}{path}",
+            data=body,
+            params=self.prepare_param(param.copy()) if param is not None else None,
+            verify=True,
+            headers=headers,
+        )
+
     def prepare_param(self, params: dict[str, Any]) -> dict[str, Any]:
         for k, val in params.items():
             if isinstance(val, datetime.timedelta):

--- a/spicepy/_status.py
+++ b/spicepy/_status.py
@@ -1,0 +1,63 @@
+"""Runtime health and per-component status."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+
+class ComponentStatus(StrEnum):
+    """The state of a single runtime component.
+
+    Mirrors the runtime's ``ComponentStatus``. A value the runtime adds in future
+    that this SDK does not know about is preserved as-is rather than raising, so
+    :meth:`from_value` never fails on an unrecognized status.
+    """
+
+    INITIALIZING = "Initializing"
+    READY = "Ready"
+    DISABLED = "Disabled"
+    ERROR = "Error"
+    REFRESHING = "Refreshing"
+    SHUTTING_DOWN = "ShuttingDown"
+    NOT_LOADED = "NotLoaded"
+
+    @classmethod
+    def from_value(cls, value: str) -> ComponentStatus | str:
+        """Return the matching member, or ``value`` unchanged if unrecognized."""
+        try:
+            return cls(value)
+        except ValueError:
+            return value
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@dataclass(frozen=True)
+class ConnectionDetails:
+    """The status of one runtime connection."""
+
+    name: str
+    """Name of the connection: ``http``, ``flight``, ``metrics`` or ``opentelemetry``."""
+
+    endpoint: str
+    """Endpoint the connection is served on, or ``N/A`` when the component is disabled."""
+
+    status: ComponentStatus | str
+    """Status of the component."""
+
+    @property
+    def is_ready(self) -> bool:
+        """Whether this component is ready to accept connections."""
+        return self.status == ComponentStatus.READY
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ConnectionDetails:
+        """Build from a single ``/v1/status`` response entry."""
+        return cls(
+            name=data.get("name", ""),
+            endpoint=data.get("endpoint", ""),
+            status=ComponentStatus.from_value(data.get("status", "")),
+        )

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -438,6 +438,26 @@ class TestHttpRequestsSendRequestRaw:
         sent_headers = mock_session.get.call_args.kwargs["headers"]
         assert sent_headers["X-API-Key"] == "secret"
 
+    @patch("spicepy._http.Session")
+    def test_does_not_mutate_caller_headers(self, mock_session_class: MagicMock) -> None:
+        """The caller's headers dict is left untouched; session headers still win."""
+        mock_session = MagicMock()
+        mock_session.get.return_value = MagicMock(spec=Response)
+        mock_session_class.return_value = mock_session
+
+        http = HttpRequests("http://example.com", {"X-API-Key": "session"})
+        caller_headers = {"X-API-Key": "caller", "Content-Type": "application/json"}
+        http.send_request_raw("GET", "/v1/ready", headers=caller_headers)
+
+        assert caller_headers == {
+            "X-API-Key": "caller",
+            "Content-Type": "application/json",
+        }
+        sent_headers = mock_session.get.call_args.kwargs["headers"]
+        assert sent_headers["X-API-Key"] == "session"
+        assert sent_headers["Content-Type"] == "application/json"
+        assert sent_headers["user-agent"] == SPICE_USER_AGENT
+
 
 class TestHttpRequestsRetryConfiguration:
     """Test HttpRequests retry configuration."""

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -439,7 +439,9 @@ class TestHttpRequestsSendRequestRaw:
         assert sent_headers["X-API-Key"] == "secret"
 
     @patch("spicepy._http.Session")
-    def test_does_not_mutate_caller_headers(self, mock_session_class: MagicMock) -> None:
+    def test_does_not_mutate_caller_headers(
+        self, mock_session_class: MagicMock
+    ) -> None:
         """The caller's headers dict is left untouched; session headers still win."""
         mock_session = MagicMock()
         mock_session.get.return_value = MagicMock(spec=Response)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -386,6 +386,59 @@ class TestHttpRequestsSendRequest:
         )
 
 
+class TestHttpRequestsSendRequestRaw:
+    """Test HttpRequests.send_request_raw method."""
+
+    @patch("spicepy._http.Session")
+    def test_returns_response_without_decoding(
+        self, mock_session_class: MagicMock
+    ) -> None:
+        """The raw Response is returned, not a decoded body."""
+        mock_session = MagicMock()
+        mock_session.headers = {}
+        mock_response = MagicMock(spec=Response)
+        mock_session.get.return_value = mock_response
+        mock_session_class.return_value = mock_session
+
+        http = HttpRequests("http://example.com", {})
+        result = http.send_request_raw("GET", "/v1/ready")
+
+        assert result is mock_response
+        mock_response.json.assert_not_called()
+
+    @patch("spicepy._http.Session")
+    def test_does_not_raise_on_error_status(
+        self, mock_session_class: MagicMock
+    ) -> None:
+        """A non-2xx status is left to the caller to interpret."""
+        mock_session = MagicMock()
+        mock_session.headers = {}
+        mock_response = MagicMock(spec=Response)
+        mock_response.status_code = 503
+        mock_session.get.return_value = mock_response
+        mock_session_class.return_value = mock_session
+
+        http = HttpRequests("http://example.com", {})
+        result = http.send_request_raw("GET", "/v1/ready")
+
+        assert result.status_code == 503
+        mock_response.raise_for_status.assert_not_called()
+
+    @patch("spicepy._http.Session")
+    def test_merges_session_headers(self, mock_session_class: MagicMock) -> None:
+        """Session headers are applied, as with send_request."""
+        mock_session = MagicMock()
+        mock_session.headers = {"X-API-Key": "secret"}
+        mock_session.get.return_value = MagicMock(spec=Response)
+        mock_session_class.return_value = mock_session
+
+        http = HttpRequests("http://example.com", {"X-API-Key": "secret"})
+        http.send_request_raw("GET", "/v1/ready")
+
+        sent_headers = mock_session.get.call_args.kwargs["headers"]
+        assert sent_headers["X-API-Key"] == "secret"
+
+
 class TestHttpRequestsRetryConfiguration:
     """Test HttpRequests retry configuration."""
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -50,7 +50,9 @@ class TestConnectionDetails:
 
     def test_from_dict(self) -> None:
         """Parses a single /v1/status entry."""
-        details = ConnectionDetails.from_dict({"name": "flight", "endpoint": "127.0.0.1:50051", "status": "Ready"})
+        details = ConnectionDetails.from_dict(
+            {"name": "flight", "endpoint": "127.0.0.1:50051", "status": "Ready"}
+        )
         assert details.name == "flight"
         assert details.endpoint == "127.0.0.1:50051"
         assert details.status == ComponentStatus.READY
@@ -58,7 +60,9 @@ class TestConnectionDetails:
 
     def test_from_dict_not_ready(self) -> None:
         """A non-Ready component reports is_ready False."""
-        details = ConnectionDetails.from_dict({"name": "metrics", "endpoint": "N/A", "status": "Disabled"})
+        details = ConnectionDetails.from_dict(
+            {"name": "metrics", "endpoint": "N/A", "status": "Disabled"}
+        )
         assert details.status == ComponentStatus.DISABLED
         assert not details.is_ready
 
@@ -71,7 +75,9 @@ class TestConnectionDetails:
 
     def test_unknown_status_is_not_ready(self) -> None:
         """An unrecognized status is never treated as ready."""
-        details = ConnectionDetails.from_dict({"name": "flight", "endpoint": "x", "status": "SomethingNew"})
+        details = ConnectionDetails.from_dict(
+            {"name": "flight", "endpoint": "x", "status": "SomethingNew"}
+        )
         assert details.status == "SomethingNew"
         assert not details.is_ready
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -135,6 +135,18 @@ class TestRuntimeStatus:
         with pytest.raises(SpiceAIError, match="expected a list of components"):
             _client_with_http(http).runtime_status()
 
+    @pytest.mark.parametrize("entry", ["flight", 3, None, ["flight"]])
+    def test_non_object_entry_raises(self, entry: object) -> None:
+        """A list entry that is not an object is a clear error, not AttributeError."""
+        http = MagicMock()
+        http.send_request.return_value = [
+            {"name": "http", "endpoint": "127.0.0.1:8090", "status": "Ready"},
+            entry,
+        ]
+
+        with pytest.raises(SpiceAIError, match="expected component 1 to be an object"):
+            _client_with_http(http).runtime_status()
+
 
 class TestIsReady:
     """Test Client.is_ready."""

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,158 @@
+"""Unit tests for spicepy._status and the Client runtime status methods."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from spicepy._status import ComponentStatus, ConnectionDetails
+from spicepy.error import SpiceAIError
+
+pytestmark = pytest.mark.unit
+
+
+class TestComponentStatus:
+    """Test the ComponentStatus enum."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Initializing",
+            "Ready",
+            "Disabled",
+            "Error",
+            "Refreshing",
+            "ShuttingDown",
+            "NotLoaded",
+        ],
+    )
+    def test_known_values_map_to_members(self, value: str) -> None:
+        """Every runtime status maps onto an enum member."""
+        status = ComponentStatus.from_value(value)
+        assert isinstance(status, ComponentStatus)
+        assert status.value == value
+        assert str(status) == value
+
+    def test_unknown_value_is_preserved(self) -> None:
+        """A status this SDK version does not know is returned unchanged."""
+        status = ComponentStatus.from_value("SomethingNew")
+        assert status == "SomethingNew"
+        assert not isinstance(status, ComponentStatus)
+
+    def test_is_str_enum(self) -> None:
+        """Members compare equal to their wire value."""
+        assert ComponentStatus.READY == "Ready"
+
+
+class TestConnectionDetails:
+    """Test the ConnectionDetails dataclass."""
+
+    def test_from_dict(self) -> None:
+        """Parses a single /v1/status entry."""
+        details = ConnectionDetails.from_dict({"name": "flight", "endpoint": "127.0.0.1:50051", "status": "Ready"})
+        assert details.name == "flight"
+        assert details.endpoint == "127.0.0.1:50051"
+        assert details.status == ComponentStatus.READY
+        assert details.is_ready
+
+    def test_from_dict_not_ready(self) -> None:
+        """A non-Ready component reports is_ready False."""
+        details = ConnectionDetails.from_dict({"name": "metrics", "endpoint": "N/A", "status": "Disabled"})
+        assert details.status == ComponentStatus.DISABLED
+        assert not details.is_ready
+
+    def test_from_dict_missing_fields(self) -> None:
+        """Missing fields default rather than raising."""
+        details = ConnectionDetails.from_dict({})
+        assert details.name == ""
+        assert details.endpoint == ""
+        assert not details.is_ready
+
+    def test_unknown_status_is_not_ready(self) -> None:
+        """An unrecognized status is never treated as ready."""
+        details = ConnectionDetails.from_dict({"name": "flight", "endpoint": "x", "status": "SomethingNew"})
+        assert details.status == "SomethingNew"
+        assert not details.is_ready
+
+
+def _client_with_http(http: MagicMock):
+    """Build a Client without running __init__, with a stubbed http attribute."""
+    from spicepy import Client
+
+    client = object.__new__(Client)
+    client.http = http
+    return client
+
+
+class TestRuntimeStatus:
+    """Test Client.runtime_status."""
+
+    def test_returns_all_components(self) -> None:
+        """Each entry in the response becomes a ConnectionDetails."""
+        http = MagicMock()
+        http.send_request.return_value = [
+            {"name": "http", "endpoint": "127.0.0.1:8090", "status": "Ready"},
+            {"name": "flight", "endpoint": "127.0.0.1:50051", "status": "Initializing"},
+            {"name": "metrics", "endpoint": "N/A", "status": "Disabled"},
+            {
+                "name": "opentelemetry",
+                "endpoint": "127.0.0.1:50051",
+                "status": "Initializing",
+            },
+        ]
+
+        components = _client_with_http(http).runtime_status()
+
+        http.send_request.assert_called_once_with("GET", "/v1/status")
+        assert [c.name for c in components] == [
+            "http",
+            "flight",
+            "metrics",
+            "opentelemetry",
+        ]
+        assert components[0].is_ready
+        assert not components[1].is_ready
+        assert components[1].status == ComponentStatus.INITIALIZING
+
+    def test_empty_response(self) -> None:
+        """An empty list is valid and yields no components."""
+        http = MagicMock()
+        http.send_request.return_value = []
+        assert _client_with_http(http).runtime_status() == []
+
+    def test_non_list_response_raises(self) -> None:
+        """A response that is not a list is an error, not silently empty."""
+        http = MagicMock()
+        http.send_request.return_value = {"not": "a list"}
+
+        with pytest.raises(SpiceAIError, match="expected a list of components"):
+            _client_with_http(http).runtime_status()
+
+
+class TestIsReady:
+    """Test Client.is_ready."""
+
+    def test_ready(self) -> None:
+        """HTTP 200 means ready."""
+        http = MagicMock()
+        http.send_request_raw.return_value = MagicMock(status_code=200)
+
+        assert _client_with_http(http).is_ready() is True
+        http.send_request_raw.assert_called_once_with("GET", "/v1/ready")
+
+    def test_not_ready(self) -> None:
+        """HTTP 503 means not ready, and is not an error."""
+        http = MagicMock()
+        http.send_request_raw.return_value = MagicMock(status_code=503)
+
+        assert _client_with_http(http).is_ready() is False
+
+    @pytest.mark.parametrize("status_code", [400, 401, 404, 500])
+    def test_unexpected_status_raises(self, status_code: int) -> None:
+        """Any other status is a failed probe, distinct from 'not ready'."""
+        http = MagicMock()
+        http.send_request_raw.return_value = MagicMock(status_code=status_code)
+
+        with pytest.raises(SpiceAIError, match="Unexpected response from /v1/ready"):
+            _client_with_http(http).is_ready()


### PR DESCRIPTION
## What

Adds two runtime health methods to `Client`:

- `runtime_status()` → `list[ConnectionDetails]`, wrapping `GET /v1/status`. One entry
  per runtime connection (`http`, `flight`, `metrics`, `opentelemetry`) with that
  component's endpoint and `ComponentStatus`.
- `is_ready()` → `bool`, wrapping `GET /v1/ready`.

`ComponentStatus` and `ConnectionDetails` are exported from `spicepy`.

## Why

Neither endpoint was reachable from this SDK, so a Python user waiting for a runtime
to come up — or diagnosing one that came up wrong — had to hand-roll `requests` calls
alongside the client they already had configured.

`/v1/ready` collapses the runtime to one boolean; `/v1/status` says *which* component
is not ready, which is the difference between "not up yet" and "Flight is failing".
Neither requires cluster mode or extra configuration, so both work on a default
`spice run`.

Three details worth a reviewer's eye:

- `/v1/ready` answers `text/plain` and uses `503` to mean "not ready", so it cannot go
  through `send_request`, which calls `raise_for_status()` and then `.json()`. This adds
  `HttpRequests.send_request_raw` for endpoints where the status code carries the
  meaning or the body is not JSON.
- `is_ready()` returns `False` for the runtime's `503` and raises `SpiceAIError` for
  anything else, so "not ready" and "could not ask" stay distinct.
- `ComponentStatus.from_value` returns an unrecognized status as a plain `str` rather
  than raising, so a status variant added by a future runtime does not break parsing.
  An unknown status is never treated as ready.

Part of aligning runtime health/status coverage across the Spice SDKs.

## Verification

- [x] `make test-unit` — 404 passed (up from 379; 25 new tests)
- [x] `make type-check` (mypy) — success, no issues in 11 source files
- [x] `ruff check` on the new files — clean; whole-repo error count unchanged from
      `trunk` (2 pre-existing `PLR0917` in `_client.py`, untouched here)
- [x] `ruff format --check` on the new files — clean
- [x] `pylint` — 9.27/10, above the 8.0 gate
- [ ] Integration tests (`make test-integration`) — not run; they require a live
      runtime, which is not available in this environment.

Note on the 8 remaining `test-unit` failures: they are the pre-existing
`adbc_driver_manager` parameterized-query tests in `tests/test_main.py`, and they fail
identically on unmodified `trunk` here. This change adds no new failures.

Scoped deliberately to additions only — I avoided running `make format`, which with the
current `ruff>=0.15.12` would reformat 15 files unrelated to this change.