### PR TITLE
feat: add Client.search for vector, keyword, and hybrid search

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,15 +135,34 @@ jobs:
         run: |
           spice init spice_qs
           cd spice_qs
-          spice add spiceai/quickstart
+          # Define the dataset inline instead of `spice add spiceai/quickstart`.
+          # Pulling it from the Spicepod registry made every PR's integration tests
+          # depend on a remote service, and when that service started returning a
+          # JSON error body under `Content-Type: application/zip`, every open PR
+          # failed at once on "Failed to extract Spicepod archive: Could not find
+          # EOCD". This is the same dataset spiceai/quickstart defines.
+          cat >> spicepod.yaml <<'YAML'
+
+          datasets:
+            - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+              name: taxi_trips
+              description: taxi trips in s3
+              params:
+                file_format: parquet
+              acceleration:
+                enabled: true
+          YAML
           spiced &> spice.log &
-          # Wait for runtime to be ready (poll /v1/ready endpoint)
-          for i in {1..60}; do
-            if curl -s http://localhost:8090/v1/ready > /dev/null 2>&1; then
-              echo "Spice runtime is ready"
+          # Wait until the dataset is queryable, not merely until the runtime is up:
+          # /v1/ready returns before an accelerated dataset finishes loading, which
+          # races the tests into "table 'taxi_trips' not found".
+          for i in {1..120}; do
+            if curl -s -X POST http://localhost:8090/v1/sql \
+                 -d 'SELECT count(*) AS n FROM taxi_trips' 2>/dev/null | grep -q '"n"'; then
+              echo "Spice runtime is ready and taxi_trips is queryable"
               break
             fi
-            echo "Waiting for Spice runtime to be ready... ($i/60)"
+            echo "Waiting for Spice runtime and taxi_trips... ($i/120)"
             sleep 1
           done
 
@@ -154,20 +173,32 @@ jobs:
           export PATH="$HOME/.spice/bin:$PATH"
           spice init spice_qs
           cd spice_qs
-          spice add spiceai/quickstart
+          # Inline dataset rather than a registry fetch — see the non-Windows step.
+          cat >> spicepod.yaml <<'YAML'
+
+          datasets:
+            - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+              name: taxi_trips
+              description: taxi trips in s3
+              params:
+                file_format: parquet
+              acceleration:
+                enabled: true
+          YAML
           nohup spiced > spice.log 2>&1 &
-          # Wait for runtime to be ready (poll /v1/ready endpoint)
-          for i in $(seq 1 120); do
-            if curl -s http://localhost:8090/v1/ready > /dev/null 2>&1; then
-              echo "Spice runtime is ready"
+          # Wait until the dataset is queryable — see the non-Windows step.
+          for i in $(seq 1 180); do
+            if curl -s -X POST http://localhost:8090/v1/sql \
+                 -d 'SELECT count(*) AS n FROM taxi_trips' 2>/dev/null | grep -q '"n"'; then
+              echo "Spice runtime is ready and taxi_trips is queryable"
               exit 0
             fi
-            echo "Waiting for Spice runtime to be ready... ($i/120)"
+            echo "Waiting for Spice runtime and taxi_trips... ($i/180)"
             sleep 1
           done
           echo "=== spice log ==="
           cat spice.log || true
-          echo "Spice runtime did not become ready within 120 seconds"
+          echo "taxi_trips did not become queryable within 180 seconds"
           exit 1
 
       # The Windows readiness poll above runs inside WSL and only checks the

--- a/README.md
+++ b/README.md
@@ -128,6 +128,47 @@ Once a `Client` is obtained queries can be made using the `query()` function. Th
 
 A custom timeout can be set by passing the `timeout` parameter in the `query` function call. If no timeout is specified, it will default to a 10 min timeout then cancel the query, and a TimeoutError exception will be raised.
 
+### Search
+
+`search()` runs vector similarity, keyword, and hybrid search against datasets that have an
+embedding column and a loaded embedding model.
+
+```python
+from spicepy import Client
+
+client = Client()
+
+response = client.search("tickets to Tokyo", datasets=["app_messages"], limit=3)
+
+print(f"{len(response)} matches in {response.duration_ms}ms")
+for match in response:
+    print(match.dataset, match.score, match.primary_key, match.matches)
+```
+
+Only `text` is positional; every option is keyword-only:
+
+- **text** (string, required): The query to find similar documents for.
+- **datasets** (list of string, optional): Restrict the search to these datasets. Omit to search every dataset with an embedding column.
+- **limit** (int, optional): Maximum matches to return per dataset.
+- **where** (string, optional): An SQL predicate applied before the search, without the `WHERE` keyword — for example `"city = 'Tokyo'"`.
+- **additional_columns** (list of string, optional): Extra columns to return. A column that is part of the primary key is returned in `match.primary_key` rather than `match.data`.
+- **keywords** (list of string, optional): Pre-filter the embedding column with a lexical search before the vector search runs, making the search hybrid.
+
+```python
+response = client.search(
+    "tickets to Tokyo",
+    datasets=["app_messages"],
+    where="city = 'Tokyo'",
+    additional_columns=["timestamp"],
+    keywords=["plane", "tickets"],
+)
+```
+
+Each `SearchMatch` carries the `dataset` it was found in, its similarity `score`, the matched
+column values in `matches`, the row's `primary_key`, the columns requested via
+`additional_columns` in `data`, and any `metadata`. The runtime omits the last three when
+empty; they default to `{}` so they can be read without a guard.
+
 ## Documentation
 
 Check out our [Documentation](https://docs.spice.ai/sdks/python-sdk) to learn more about how to use the Python SDK.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,10 @@ ignore = [
     "ANN205", # Missing return type annotation for staticmethod
     "ANN206", # Missing return type annotation for classmethod
     "PLR0913", # Too many arguments in function definition
+    "PLR0917", # Too many positional arguments (stabilized in ruff 0.16; the
+               # positional counterpart of PLR0913, already ignored above.
+               # Satisfying it would mean making existing client constructor
+               # parameters keyword-only, which is a breaking API change.)
     "PLR0911", # Too many return statements
     "PLR0915", # Too many statements
     "S101",   # Use of assert detected (needed for tests)

--- a/spicepy/__init__.py
+++ b/spicepy/__init__.py
@@ -10,11 +10,14 @@ from ._client import Client
 from ._dataframe import SpiceDataFrame
 from ._expr import Expr, WindowFrame, case, col, lit
 from ._http import RefreshOpts
+from ._search import SearchMatch, SearchResponse
 
 __all__ = [
     "Client",
     "Expr",
     "RefreshOpts",
+    "SearchMatch",
+    "SearchResponse",
     "SpiceDataFrame",
     "WindowFrame",
     "case",

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -31,7 +31,10 @@ from .params import infer_arrow_type
 
 
 def is_macos_arm64() -> bool:
-    return platform.platform().lower().startswith("macos") and platform.machine() == "arm64"
+    return (
+        platform.platform().lower().startswith("macos")
+        and platform.machine() == "arm64"
+    )
 
 
 try:
@@ -95,7 +98,9 @@ class _ADBCClient:
         # Add authentication if API key provided
         if self._api_key:
             db_kwargs[adbc_driver_manager.DatabaseOptions.USERNAME.value] = ""
-            db_kwargs[adbc_driver_manager.DatabaseOptions.PASSWORD.value] = self._api_key
+            db_kwargs[adbc_driver_manager.DatabaseOptions.PASSWORD.value] = (
+                self._api_key
+            )
 
         # Create low-level database and connection (avoids dbapi autocommit warning)
         self._db = adbc_driver_flightsql.connect(self._uri, db_kwargs=db_kwargs)
@@ -120,7 +125,11 @@ class _ADBCClient:
 
         for param in params:
             # Check if param is a tuple of (value, arrow_type)
-            if isinstance(param, tuple) and len(param) == 2 and isinstance(param[1], pa.DataType):
+            if (
+                isinstance(param, tuple)
+                and len(param) == 2
+                and isinstance(param[1], pa.DataType)
+            ):
                 value, arrow_type = param
                 param_values.append(value)
                 param_types.append(arrow_type)
@@ -134,7 +143,9 @@ class _ADBCClient:
             param_arrays.append(pa.array([value], type=arrow_type))
 
         # Create parameter schema with positional field names ($1, $2, etc.)
-        param_fields = [pa.field(f"${i + 1}", param_types[i]) for i in range(len(params))]
+        param_fields = [
+            pa.field(f"${i + 1}", param_types[i]) for i in range(len(params))
+        ]
         param_schema = pa.schema(param_fields)
 
         return pa.record_batch(param_arrays, schema=param_schema)
@@ -199,7 +210,11 @@ class _Cert:
         tls_root_cert,
     ):
         if tls_root_cert is not None:
-            tls_root_cert = tls_root_cert if isinstance(tls_root_cert, Path) else Path(tls_root_cert)
+            tls_root_cert = (
+                tls_root_cert
+                if isinstance(tls_root_cert, Path)
+                else Path(tls_root_cert)
+            )
         else:
             tls_root_cert = Path(certifi.where())
 
@@ -236,9 +251,15 @@ class _SpiceFlight:
         connect_kwargs = {"tls_root_certs": tls_root_certs}
         if tls_client_certificate is not None and tls_client_key is not None:
             cert_path = (
-                tls_client_certificate if isinstance(tls_client_certificate, Path) else Path(tls_client_certificate)
+                tls_client_certificate
+                if isinstance(tls_client_certificate, Path)
+                else Path(tls_client_certificate)
             )
-            key_path = tls_client_key if isinstance(tls_client_key, Path) else Path(tls_client_key)
+            key_path = (
+                tls_client_key
+                if isinstance(tls_client_key, Path)
+                else Path(tls_client_key)
+            )
             with open(cert_path, "rb") as f:
                 connect_kwargs["cert_chain"] = f.read()
             with open(key_path, "rb") as f:
@@ -246,7 +267,9 @@ class _SpiceFlight:
         self._flight_client = flight.connect(grpc, **connect_kwargs)
         self._api_key = api_key
         self.headers = [_SpiceFlight._user_agent(user_agent)]
-        self._flight_options = flight.FlightCallOptions(headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS)
+        self._flight_options = flight.FlightCallOptions(
+            headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS
+        )
         self._authenticate()
 
     def _authenticate(self):
@@ -255,10 +278,14 @@ class _SpiceFlight:
                 self._flight_client.authenticate_basic_token("", self._api_key),
                 _SpiceFlight._user_agent(),
             ]
-            self._flight_options = flight.FlightCallOptions(headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS)
+            self._flight_options = flight.FlightCallOptions(
+                headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS
+            )
         else:
             self.headers = [_SpiceFlight._user_agent()]
-            self._flight_options = flight.FlightCallOptions(headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS)
+            self._flight_options = flight.FlightCallOptions(
+                headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS
+            )
 
     def query(self, query: str, **kwargs) -> flight.FlightStreamReader:
         timeout = kwargs.get("timeout")
@@ -266,19 +293,27 @@ class _SpiceFlight:
         if timeout is not None:
             if not isinstance(timeout, int) or timeout <= 0:
                 raise ValueError("Timeout must be a positive integer")
-            self._flight_options = flight.FlightCallOptions(headers=self.headers, timeout=timeout)
+            self._flight_options = flight.FlightCallOptions(
+                headers=self.headers, timeout=timeout
+            )
 
         flight_info = self._flight_client.get_flight_info(
             flight.FlightDescriptor.for_command(query), self._flight_options
         )
 
         try:
-            reader = self._threaded_flight_do_get(ticket=flight_info.endpoints[0].ticket)
+            reader = self._threaded_flight_do_get(
+                ticket=flight_info.endpoints[0].ticket
+            )
         except flight.FlightUnauthenticatedError:
             self._authenticate()
-            reader = self._threaded_flight_do_get(ticket=flight_info.endpoints[0].ticket)
+            reader = self._threaded_flight_do_get(
+                ticket=flight_info.endpoints[0].ticket
+            )
         except flight.FlightTimedOutError as exc:
-            raise TimeoutError(f"Query timed out and was canceled after {timeout} seconds.") from exc
+            raise TimeoutError(
+                f"Query timed out and was canceled after {timeout} seconds."
+            ) from exc
 
         return reader
 
@@ -424,7 +459,9 @@ class Client:
             ValueError: If params is None
         """
         if params is None:
-            raise ValueError("params must be a list, not None. Use [] for queries without parameters.")
+            raise ValueError(
+                "params must be a list, not None. Use [] for queries without parameters."
+            )
         adbc = self._ensure_adbc_client()
         return adbc.query_with_params(sql, params)
 
@@ -492,8 +529,12 @@ class Client:
         try:
             import polars as pl
         except ImportError as exc:
-            raise ImportError("polars is not installed. Install it with: pip install spicepy[polars]") from exc
-        return cast("pl.DataFrame", pl.from_arrow(self._read_table(sql, params, timeout)))
+            raise ImportError(
+                "polars is not installed. Install it with: pip install spicepy[polars]"
+            ) from exc
+        return cast(
+            "pl.DataFrame", pl.from_arrow(self._read_table(sql, params, timeout))
+        )
 
     def query_pylist(
         self,
@@ -551,13 +592,17 @@ class Client:
 
     def catalogs(self) -> list[str]:
         """List catalog names visible to this connection."""
-        rows = self.query_pylist("SELECT DISTINCT catalog_name FROM information_schema.schemata ORDER BY catalog_name")
+        rows = self.query_pylist(
+            "SELECT DISTINCT catalog_name FROM information_schema.schemata ORDER BY catalog_name"
+        )
         return [r["catalog_name"] for r in rows]
 
     def schemas(self, catalog: str | None = None) -> list[str]:
         """List schema names, optionally restricted to a catalog."""
         if catalog is None:
-            rows = self.query_pylist("SELECT schema_name FROM information_schema.schemata ORDER BY schema_name")
+            rows = self.query_pylist(
+                "SELECT schema_name FROM information_schema.schemata ORDER BY schema_name"
+            )
         else:
             from ._sql import quote_literal
 
@@ -690,11 +735,17 @@ class Client:
 
         return self.from_arrow(pa.Table.from_pydict(data))
 
-    def refresh_dataset(self, dataset: str, refresh_opts: RefreshOpts | None = None) -> Any:
+    def refresh_dataset(
+        self, dataset: str, refresh_opts: RefreshOpts | None = None
+    ) -> Any:
         response = self.http.send_request(
             "POST",
             f"/v1/datasets/{dataset}/acceleration/refresh",
-            body=(json.dumps(refresh_opts.to_dict()) if refresh_opts is not None else json.dumps({})),
+            body=(
+                json.dumps(refresh_opts.to_dict())
+                if refresh_opts is not None
+                else json.dumps({})
+            ),
             headers={"Content-Type": "application/json"},
         )
 

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import certifi
 import pyarrow as pa
+from requests.exceptions import HTTPError
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -24,15 +25,13 @@ from pyarrow._flight import (
 
 from . import config
 from ._http import HttpRequests, RefreshOpts
-from ._search import SearchResponse, build_search_body
+from ._search import SearchResponse, build_search_body, search_error_message
+from .error import SpiceAIError
 from .params import infer_arrow_type
 
 
 def is_macos_arm64() -> bool:
-    return (
-        platform.platform().lower().startswith("macos")
-        and platform.machine() == "arm64"
-    )
+    return platform.platform().lower().startswith("macos") and platform.machine() == "arm64"
 
 
 try:
@@ -96,9 +95,7 @@ class _ADBCClient:
         # Add authentication if API key provided
         if self._api_key:
             db_kwargs[adbc_driver_manager.DatabaseOptions.USERNAME.value] = ""
-            db_kwargs[adbc_driver_manager.DatabaseOptions.PASSWORD.value] = (
-                self._api_key
-            )
+            db_kwargs[adbc_driver_manager.DatabaseOptions.PASSWORD.value] = self._api_key
 
         # Create low-level database and connection (avoids dbapi autocommit warning)
         self._db = adbc_driver_flightsql.connect(self._uri, db_kwargs=db_kwargs)
@@ -123,11 +120,7 @@ class _ADBCClient:
 
         for param in params:
             # Check if param is a tuple of (value, arrow_type)
-            if (
-                isinstance(param, tuple)
-                and len(param) == 2
-                and isinstance(param[1], pa.DataType)
-            ):
+            if isinstance(param, tuple) and len(param) == 2 and isinstance(param[1], pa.DataType):
                 value, arrow_type = param
                 param_values.append(value)
                 param_types.append(arrow_type)
@@ -141,9 +134,7 @@ class _ADBCClient:
             param_arrays.append(pa.array([value], type=arrow_type))
 
         # Create parameter schema with positional field names ($1, $2, etc.)
-        param_fields = [
-            pa.field(f"${i + 1}", param_types[i]) for i in range(len(params))
-        ]
+        param_fields = [pa.field(f"${i + 1}", param_types[i]) for i in range(len(params))]
         param_schema = pa.schema(param_fields)
 
         return pa.record_batch(param_arrays, schema=param_schema)
@@ -208,11 +199,7 @@ class _Cert:
         tls_root_cert,
     ):
         if tls_root_cert is not None:
-            tls_root_cert = (
-                tls_root_cert
-                if isinstance(tls_root_cert, Path)
-                else Path(tls_root_cert)
-            )
+            tls_root_cert = tls_root_cert if isinstance(tls_root_cert, Path) else Path(tls_root_cert)
         else:
             tls_root_cert = Path(certifi.where())
 
@@ -249,15 +236,9 @@ class _SpiceFlight:
         connect_kwargs = {"tls_root_certs": tls_root_certs}
         if tls_client_certificate is not None and tls_client_key is not None:
             cert_path = (
-                tls_client_certificate
-                if isinstance(tls_client_certificate, Path)
-                else Path(tls_client_certificate)
+                tls_client_certificate if isinstance(tls_client_certificate, Path) else Path(tls_client_certificate)
             )
-            key_path = (
-                tls_client_key
-                if isinstance(tls_client_key, Path)
-                else Path(tls_client_key)
-            )
+            key_path = tls_client_key if isinstance(tls_client_key, Path) else Path(tls_client_key)
             with open(cert_path, "rb") as f:
                 connect_kwargs["cert_chain"] = f.read()
             with open(key_path, "rb") as f:
@@ -265,9 +246,7 @@ class _SpiceFlight:
         self._flight_client = flight.connect(grpc, **connect_kwargs)
         self._api_key = api_key
         self.headers = [_SpiceFlight._user_agent(user_agent)]
-        self._flight_options = flight.FlightCallOptions(
-            headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS
-        )
+        self._flight_options = flight.FlightCallOptions(headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS)
         self._authenticate()
 
     def _authenticate(self):
@@ -276,14 +255,10 @@ class _SpiceFlight:
                 self._flight_client.authenticate_basic_token("", self._api_key),
                 _SpiceFlight._user_agent(),
             ]
-            self._flight_options = flight.FlightCallOptions(
-                headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS
-            )
+            self._flight_options = flight.FlightCallOptions(headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS)
         else:
             self.headers = [_SpiceFlight._user_agent()]
-            self._flight_options = flight.FlightCallOptions(
-                headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS
-            )
+            self._flight_options = flight.FlightCallOptions(headers=self.headers, timeout=DEFAULT_QUERY_TIMEOUT_SECS)
 
     def query(self, query: str, **kwargs) -> flight.FlightStreamReader:
         timeout = kwargs.get("timeout")
@@ -291,27 +266,19 @@ class _SpiceFlight:
         if timeout is not None:
             if not isinstance(timeout, int) or timeout <= 0:
                 raise ValueError("Timeout must be a positive integer")
-            self._flight_options = flight.FlightCallOptions(
-                headers=self.headers, timeout=timeout
-            )
+            self._flight_options = flight.FlightCallOptions(headers=self.headers, timeout=timeout)
 
         flight_info = self._flight_client.get_flight_info(
             flight.FlightDescriptor.for_command(query), self._flight_options
         )
 
         try:
-            reader = self._threaded_flight_do_get(
-                ticket=flight_info.endpoints[0].ticket
-            )
+            reader = self._threaded_flight_do_get(ticket=flight_info.endpoints[0].ticket)
         except flight.FlightUnauthenticatedError:
             self._authenticate()
-            reader = self._threaded_flight_do_get(
-                ticket=flight_info.endpoints[0].ticket
-            )
+            reader = self._threaded_flight_do_get(ticket=flight_info.endpoints[0].ticket)
         except flight.FlightTimedOutError as exc:
-            raise TimeoutError(
-                f"Query timed out and was canceled after {timeout} seconds."
-            ) from exc
+            raise TimeoutError(f"Query timed out and was canceled after {timeout} seconds.") from exc
 
         return reader
 
@@ -457,9 +424,7 @@ class Client:
             ValueError: If params is None
         """
         if params is None:
-            raise ValueError(
-                "params must be a list, not None. Use [] for queries without parameters."
-            )
+            raise ValueError("params must be a list, not None. Use [] for queries without parameters.")
         adbc = self._ensure_adbc_client()
         return adbc.query_with_params(sql, params)
 
@@ -527,12 +492,8 @@ class Client:
         try:
             import polars as pl
         except ImportError as exc:
-            raise ImportError(
-                "polars is not installed. Install it with: pip install spicepy[polars]"
-            ) from exc
-        return cast(
-            "pl.DataFrame", pl.from_arrow(self._read_table(sql, params, timeout))
-        )
+            raise ImportError("polars is not installed. Install it with: pip install spicepy[polars]") from exc
+        return cast("pl.DataFrame", pl.from_arrow(self._read_table(sql, params, timeout)))
 
     def query_pylist(
         self,
@@ -590,19 +551,13 @@ class Client:
 
     def catalogs(self) -> list[str]:
         """List catalog names visible to this connection."""
-        rows = self.query_pylist(
-            "SELECT DISTINCT catalog_name FROM information_schema.schemata "
-            "ORDER BY catalog_name"
-        )
+        rows = self.query_pylist("SELECT DISTINCT catalog_name FROM information_schema.schemata ORDER BY catalog_name")
         return [r["catalog_name"] for r in rows]
 
     def schemas(self, catalog: str | None = None) -> list[str]:
         """List schema names, optionally restricted to a catalog."""
         if catalog is None:
-            rows = self.query_pylist(
-                "SELECT schema_name FROM information_schema.schemata "
-                "ORDER BY schema_name"
-            )
+            rows = self.query_pylist("SELECT schema_name FROM information_schema.schemata ORDER BY schema_name")
         else:
             from ._sql import quote_literal
 
@@ -617,8 +572,7 @@ class Client:
         """List table names, optionally restricted to a schema."""
         if schema is None:
             rows = self.query_pylist(
-                "SELECT table_name FROM information_schema.tables "
-                "ORDER BY table_schema, table_name"
+                "SELECT table_name FROM information_schema.tables ORDER BY table_schema, table_name"
             )
         else:
             from ._sql import quote_literal
@@ -736,17 +690,11 @@ class Client:
 
         return self.from_arrow(pa.Table.from_pydict(data))
 
-    def refresh_dataset(
-        self, dataset: str, refresh_opts: RefreshOpts | None = None
-    ) -> Any:
+    def refresh_dataset(self, dataset: str, refresh_opts: RefreshOpts | None = None) -> Any:
         response = self.http.send_request(
             "POST",
             f"/v1/datasets/{dataset}/acceleration/refresh",
-            body=(
-                json.dumps(refresh_opts.to_dict())
-                if refresh_opts is not None
-                else json.dumps({})
-            ),
+            body=(json.dumps(refresh_opts.to_dict()) if refresh_opts is not None else json.dumps({})),
             headers={"Content-Type": "application/json"},
         )
 
@@ -804,12 +752,23 @@ class Client:
             keywords=keywords,
         )
 
-        response = self.http.send_request(
-            "POST",
-            "/v1/search",
-            body=json.dumps(body),
-            headers={"Content-Type": "application/json"},
-        )
+        try:
+            response = self.http.send_request(
+                "POST",
+                "/v1/search",
+                body=json.dumps(body),
+                headers={"Content-Type": "application/json"},
+            )
+        except HTTPError as err:
+            # requests reports only "400 Client Error" here; the runtime's own message
+            # is in the body and is the part that says what to fix.
+            failed = err.response
+            raise SpiceAIError(
+                search_error_message(
+                    failed.status_code if failed is not None else None,
+                    failed.text if failed is not None else None,
+                )
+            ) from err
 
         return SearchResponse.from_dict(response)
 

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -24,6 +24,7 @@ from pyarrow._flight import (
 
 from . import config
 from ._http import HttpRequests, RefreshOpts
+from ._search import SearchResponse, build_search_body
 from .params import infer_arrow_type
 
 
@@ -750,6 +751,67 @@ class Client:
         )
 
         return response
+
+    # pylint: disable=R0913
+    # pylint: disable=R0917
+    def search(
+        self,
+        text: str,
+        *,
+        datasets: list[str] | None = None,
+        limit: int | None = None,
+        where: str | None = None,
+        additional_columns: list[str] | None = None,
+        keywords: list[str] | None = None,
+    ) -> SearchResponse:
+        """Run a vector, keyword, or hybrid search.
+
+        Searches datasets that have an embedding column and a loaded embedding
+        model, returning the documents most similar to ``text``.
+
+        Args:
+            text: The query to find similar documents for.
+            datasets: Restrict the search to these datasets. ``None`` searches
+                every dataset with an embedding column.
+            limit: Maximum matches to return per dataset. ``None`` uses the
+                runtime's default.
+            where: An SQL predicate applied before the search, without the
+                ``WHERE`` keyword — for example ``"city = 'Tokyo'"``.
+            additional_columns: Extra dataset columns to return. A column that is
+                part of the primary key is returned in ``SearchMatch.primary_key``
+                rather than ``SearchMatch.data``.
+            keywords: Pre-filter the embedding column with a lexical search before
+                the vector search runs, making the search hybrid.
+
+        Returns:
+            A :class:`SearchResponse`. Iterating it yields each
+            :class:`SearchMatch`.
+
+        Raises:
+            SpiceAIError: if ``text`` is empty.
+
+        Example:
+            >>> response = client.search("tickets to Tokyo", datasets=["app_messages"], limit=3)
+            >>> for match in response:
+            ...     print(match.dataset, match.score, match.matches)
+        """
+        body = build_search_body(
+            text,
+            datasets=datasets,
+            limit=limit,
+            where=where,
+            additional_columns=additional_columns,
+            keywords=keywords,
+        )
+
+        response = self.http.send_request(
+            "POST",
+            "/v1/search",
+            body=json.dumps(body),
+            headers={"Content-Type": "application/json"},
+        )
+
+        return SearchResponse.from_dict(response)
 
 
 class _ArrowFlightCallThread(threading.Thread):

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -239,7 +239,7 @@ class _SpiceFlight:
             )
         return (str.encode("user-agent"), str.encode(config.SPICE_USER_AGENT))
 
-    def __init__(
+    def __init__(  # noqa: PLR0917
         self,
         grpc: str,
         api_key: str,
@@ -332,7 +332,7 @@ class _SpiceFlight:
 
 class Client:
     # pylint: disable=R0917
-    def __init__(
+    def __init__(  # noqa: PLR0917
         self,
         api_key: str | None = None,
         flight_url: str = config.DEFAULT_LOCAL_FLIGHT_URL,

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -239,7 +239,7 @@ class _SpiceFlight:
             )
         return (str.encode("user-agent"), str.encode(config.SPICE_USER_AGENT))
 
-    def __init__(  # noqa: PLR0917
+    def __init__(
         self,
         grpc: str,
         api_key: str,
@@ -332,7 +332,7 @@ class _SpiceFlight:
 
 class Client:
     # pylint: disable=R0917
-    def __init__(  # noqa: PLR0917
+    def __init__(
         self,
         api_key: str | None = None,
         flight_url: str = config.DEFAULT_LOCAL_FLIGHT_URL,

--- a/spicepy/_search.py
+++ b/spicepy/_search.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import json
 from typing import Any
 
 from .error import SpiceAIError
@@ -76,6 +77,33 @@ class SearchResponse:
 
     def __iter__(self) -> Any:
         return iter(self.results)
+
+
+def search_error_message(status_code: int | None, body: str | None) -> str:
+    """Build the message to raise for a failed search.
+
+    The runtime answers some failures with a JSON ``{"error": ...}`` body and others
+    — ``"Search cannot be run on X because it has no embeddings or full text search
+    indexes"``, for instance — with plain text. Without unpacking both, the caller is
+    left with a bare ``400 Client Error`` and no indication of what to fix.
+    """
+    detail = (body or "").strip()
+
+    if detail:
+        try:
+            parsed = json.loads(detail)
+        except ValueError:
+            pass
+        else:
+            if isinstance(parsed, dict) and parsed.get("error"):
+                detail = str(parsed["error"])
+
+    if not detail:
+        detail = "(no response body)"
+
+    if status_code is None:
+        return f"search failed: {detail}"
+    return f"search failed with status {status_code}: {detail}"
 
 
 # pylint: disable=R0913

--- a/spicepy/_search.py
+++ b/spicepy/_search.py
@@ -9,6 +9,16 @@ from typing import Any
 from .error import SpiceAIError
 
 
+def _as_mapping(value: Any) -> dict[str, Any]:
+    """Return ``value`` if it is a mapping, otherwise an empty dict.
+
+    The runtime omits these objects when empty, and a malformed or proxied
+    response can put something else there entirely. Coercing keeps the declared
+    types honest instead of handing callers a str where a dict is documented.
+    """
+    return value if isinstance(value, dict) else {}
+
+
 @dataclass
 class SearchMatch:
     """A single document matched by a search.
@@ -36,18 +46,24 @@ class SearchMatch:
     """Any additional metadata the runtime attached to the match."""
 
     @classmethod
-    def from_dict(cls, payload: dict[str, Any]) -> SearchMatch:
+    def from_dict(cls, payload: Any) -> SearchMatch:
         """Build a match from the runtime's wire format.
 
         The wire format names the similarity score ``_score``.
+
+        Raises:
+            SpiceAIError: if the match is not an object.
         """
+        if not isinstance(payload, dict):
+            raise SpiceAIError(f"unexpected search match from the runtime: {payload!r}")
+
         return cls(
             dataset=payload.get("dataset", ""),
             score=payload.get("_score", 0.0),
-            matches=payload.get("matches") or {},
-            primary_key=payload.get("primary_key") or {},
-            data=payload.get("data") or {},
-            metadata=payload.get("metadata") or {},
+            matches=_as_mapping(payload.get("matches")),
+            primary_key=_as_mapping(payload.get("primary_key")),
+            data=_as_mapping(payload.get("data")),
+            metadata=_as_mapping(payload.get("metadata")),
         )
 
 
@@ -62,16 +78,33 @@ class SearchResponse:
     """How long the runtime took to run the search."""
 
     @classmethod
-    def from_dict(cls, payload: dict[str, Any]) -> SearchResponse:
-        """Build a response from the runtime's wire format."""
+    def from_dict(cls, payload: Any) -> SearchResponse:
+        """Build a response from the runtime's wire format.
+
+        Raises:
+            SpiceAIError: if the response, or its ``results``, is not the
+                expected shape. An error page or a proxy response reaches here
+                as easily as a real result, so it fails loudly rather than
+                surfacing an AttributeError somewhere later.
+        """
         if not isinstance(payload, dict):
             raise SpiceAIError(
                 f"unexpected search response from the runtime: {payload!r}"
             )
 
+        results = payload.get("results") or []
+        if not isinstance(results, list):
+            raise SpiceAIError(
+                f"unexpected search results from the runtime: {results!r}"
+            )
+
+        duration = payload.get("duration_ms", 0)
+        if not isinstance(duration, int) or isinstance(duration, bool):
+            duration = 0
+
         return cls(
-            results=[SearchMatch.from_dict(m) for m in payload.get("results") or []],
-            duration_ms=payload.get("duration_ms", 0),
+            results=[SearchMatch.from_dict(m) for m in results],
+            duration_ms=duration,
         )
 
     def __len__(self) -> int:

--- a/spicepy/_search.py
+++ b/spicepy/_search.py
@@ -1,0 +1,110 @@
+"""Vector, keyword, and hybrid search against datasets with an embedding column."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .error import SpiceAIError
+
+
+@dataclass
+class SearchMatch:
+    """A single document matched by a search.
+
+    The runtime omits ``primary_key``, ``data``, and ``metadata`` when they are
+    empty; they default to ``{}`` here so they can be read without a guard.
+    """
+
+    dataset: str
+    """The dataset the match was found in."""
+
+    score: float
+    """Similarity of the match to the query text. Higher is closer."""
+
+    matches: dict[str, list[Any]] = field(default_factory=dict)
+    """The matched values of each searched column."""
+
+    primary_key: dict[str, Any] = field(default_factory=dict)
+    """Primary key identifying the matched row, if the dataset declares one."""
+
+    data: dict[str, Any] = field(default_factory=dict)
+    """Columns requested via ``additional_columns``."""
+
+    metadata: dict[str, Any] = field(default_factory=dict)
+    """Any additional metadata the runtime attached to the match."""
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> SearchMatch:
+        """Build a match from the runtime's wire format.
+
+        The wire format names the similarity score ``_score``.
+        """
+        return cls(
+            dataset=payload.get("dataset", ""),
+            score=payload.get("_score", 0.0),
+            matches=payload.get("matches") or {},
+            primary_key=payload.get("primary_key") or {},
+            data=payload.get("data") or {},
+            metadata=payload.get("metadata") or {},
+        )
+
+
+@dataclass
+class SearchResponse:
+    """The result of a search."""
+
+    results: list[SearchMatch] = field(default_factory=list)
+    """Matches, ordered by descending score."""
+
+    duration_ms: int = 0
+    """How long the runtime took to run the search."""
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> SearchResponse:
+        """Build a response from the runtime's wire format."""
+        if not isinstance(payload, dict):
+            raise SpiceAIError(f"unexpected search response from the runtime: {payload!r}")
+
+        return cls(
+            results=[SearchMatch.from_dict(m) for m in payload.get("results") or []],
+            duration_ms=payload.get("duration_ms", 0),
+        )
+
+    def __len__(self) -> int:
+        return len(self.results)
+
+    def __iter__(self) -> Any:
+        return iter(self.results)
+
+
+# pylint: disable=R0913
+# pylint: disable=R0917
+def build_search_body(
+    text: str,
+    datasets: list[str] | None = None,
+    limit: int | None = None,
+    where: str | None = None,
+    additional_columns: list[str] | None = None,
+    keywords: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build the ``/v1/search`` request body, omitting unset options.
+
+    Raises:
+        SpiceAIError: if ``text`` is empty.
+    """
+    if not text:
+        raise SpiceAIError("search text is required")
+
+    body: dict[str, Any] = {"text": text}
+    if datasets is not None:
+        body["datasets"] = datasets
+    if limit is not None:
+        body["limit"] = limit
+    if where is not None:
+        body["where"] = where
+    if additional_columns is not None:
+        body["additional_columns"] = additional_columns
+    if keywords is not None:
+        body["keywords"] = keywords
+    return body

--- a/spicepy/_search.py
+++ b/spicepy/_search.py
@@ -65,7 +65,9 @@ class SearchResponse:
     def from_dict(cls, payload: dict[str, Any]) -> SearchResponse:
         """Build a response from the runtime's wire format."""
         if not isinstance(payload, dict):
-            raise SpiceAIError(f"unexpected search response from the runtime: {payload!r}")
+            raise SpiceAIError(
+                f"unexpected search response from the runtime: {payload!r}"
+            )
 
         return cls(
             results=[SearchMatch.from_dict(m) for m in payload.get("results") or []],

--- a/spicepy/_search.py
+++ b/spicepy/_search.py
@@ -109,9 +109,9 @@ def search_error_message(status_code: int | None, body: str | None) -> str:
 
 
 # pylint: disable=R0913
-# pylint: disable=R0917
 def build_search_body(
     text: str,
+    *,
     datasets: list[str] | None = None,
     limit: int | None = None,
     where: str | None = None,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -178,11 +178,13 @@ class TestClientSearch:
         from requests import Response
         from requests.exceptions import HTTPError
 
+        body = (
+            b"Search cannot be run on nation because it has no embeddings"
+            b" or full text search indexes."
+        )
         failed = Response()
         failed.status_code = 400
-        failed._content = (  # pylint: disable=protected-access
-            b"Search cannot be run on nation because it has no embeddings or full text search indexes."
-        )
+        failed._content = body  # pylint: disable=protected-access
 
         client = self._client({})
         client.http.send_request.side_effect = HTTPError(response=failed)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -10,6 +10,7 @@ from spicepy._search import (
     SearchMatch,
     SearchResponse,
     build_search_body,
+    search_error_message,
 )
 from spicepy.error import SpiceAIError
 
@@ -171,3 +172,47 @@ class TestClientSearch:
         client = self._client({"results": [], "duration_ms": 0})
         with pytest.raises(TypeError):
             client.search("tickets", ["app_messages"])  # type: ignore[misc]
+
+    def test_http_error_carries_the_runtime_message(self) -> None:
+        """A bare '400 Client Error' does not say what to fix."""
+        from requests import Response
+        from requests.exceptions import HTTPError
+
+        failed = Response()
+        failed.status_code = 400
+        failed._content = (  # pylint: disable=protected-access
+            b"Search cannot be run on nation because it has no embeddings or full text search indexes."
+        )
+
+        client = self._client({})
+        client.http.send_request.side_effect = HTTPError(response=failed)
+
+        with pytest.raises(SpiceAIError, match="no embeddings or full text search"):
+            client.search("tickets", datasets=["nation"])
+
+
+class TestSearchErrorMessage:
+    """Test the message built for a failed search."""
+
+    def test_plain_text_body(self) -> None:
+        message = search_error_message(400, "No data sources provided")
+        assert "400" in message
+        assert "No data sources provided" in message
+
+    def test_json_error_body_is_unwrapped(self) -> None:
+        message = search_error_message(400, '{"error": "No data sources provided"}')
+        assert "No data sources provided" in message
+        # The JSON envelope itself should not leak into the message.
+        assert '{"error"' not in message
+
+    def test_json_without_an_error_key_is_kept_verbatim(self) -> None:
+        message = search_error_message(500, '{"detail": "boom"}')
+        assert '{"detail": "boom"}' in message
+
+    def test_empty_body(self) -> None:
+        assert "(no response body)" in search_error_message(500, "")
+        assert "(no response body)" in search_error_message(500, None)
+
+    def test_missing_status_code(self) -> None:
+        message = search_error_message(None, "something went wrong")
+        assert "something went wrong" in message

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,173 @@
+"""Unit tests for spicepy._search and Client.search."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from spicepy._search import (
+    SearchMatch,
+    SearchResponse,
+    build_search_body,
+)
+from spicepy.error import SpiceAIError
+
+
+class TestBuildSearchBody:
+    """Test request body construction."""
+
+    def test_text_only_omits_optional_fields(self) -> None:
+        assert build_search_body("tickets to Tokyo") == {"text": "tickets to Tokyo"}
+
+    def test_all_options(self) -> None:
+        body = build_search_body(
+            "tickets to Tokyo",
+            datasets=["app_messages"],
+            limit=3,
+            where="city = 'Tokyo'",
+            additional_columns=["timestamp"],
+            keywords=["plane", "tickets"],
+        )
+        assert body == {
+            "text": "tickets to Tokyo",
+            "datasets": ["app_messages"],
+            "limit": 3,
+            "where": "city = 'Tokyo'",
+            "additional_columns": ["timestamp"],
+            "keywords": ["plane", "tickets"],
+        }
+
+    def test_empty_collections_are_sent_not_dropped(self) -> None:
+        """An explicit empty list is a different request from an unset option."""
+        body = build_search_body("tickets", datasets=[], keywords=[])
+        assert body["datasets"] == []
+        assert body["keywords"] == []
+
+    def test_limit_zero_is_preserved(self) -> None:
+        """0 is falsy but explicitly supplied, so it must survive."""
+        assert build_search_body("tickets", limit=0)["limit"] == 0
+
+    def test_empty_text_raises(self) -> None:
+        with pytest.raises(SpiceAIError, match="search text is required"):
+            build_search_body("")
+
+
+class TestSearchMatch:
+    """Test decoding the runtime's wire format."""
+
+    def test_full_match(self) -> None:
+        match = SearchMatch.from_dict(
+            {
+                "matches": {"message": ["I booked us some tickets"]},
+                "dataset": "app_messages",
+                "primary_key": {"id": "6fd5a215"},
+                "data": {"timestamp": 1724716542},
+                "_score": 0.914321,
+            }
+        )
+        assert match.dataset == "app_messages"
+        assert match.score == 0.914321
+        assert match.matches == {"message": ["I booked us some tickets"]}
+        assert match.primary_key == {"id": "6fd5a215"}
+        assert match.data == {"timestamp": 1724716542}
+        assert match.metadata == {}
+
+    def test_omitted_objects_default_to_empty_dicts(self) -> None:
+        """The runtime omits data/primary_key/metadata when empty."""
+        match = SearchMatch.from_dict({"dataset": "app_messages", "_score": 0.5})
+        assert match.primary_key == {}
+        assert match.data == {}
+        assert match.metadata == {}
+        assert match.matches == {}
+        # Readable without a guard.
+        assert match.data.get("timestamp") is None
+
+    def test_score_reads_the_underscore_prefixed_wire_field(self) -> None:
+        assert SearchMatch.from_dict({"_score": 0.75}).score == 0.75
+        # `score` is not the wire name and must not be picked up.
+        assert SearchMatch.from_dict({"score": 0.75}).score == 0.0
+
+
+class TestSearchResponse:
+    """Test the response wrapper."""
+
+    def test_from_dict(self) -> None:
+        response = SearchResponse.from_dict(
+            {
+                "results": [
+                    {"dataset": "app_messages", "_score": 0.9},
+                    {"dataset": "app_messages", "_score": 0.8},
+                ],
+                "duration_ms": 42,
+            }
+        )
+        assert response.duration_ms == 42
+        assert len(response) == 2
+        assert [m.score for m in response] == [0.9, 0.8]
+
+    def test_empty_results(self) -> None:
+        response = SearchResponse.from_dict({"results": [], "duration_ms": 1})
+        assert len(response) == 0
+        assert list(response) == []
+
+    def test_missing_results_key(self) -> None:
+        assert len(SearchResponse.from_dict({"duration_ms": 1})) == 0
+
+    def test_non_dict_payload_raises(self) -> None:
+        with pytest.raises(SpiceAIError, match="unexpected search response"):
+            SearchResponse.from_dict("not a dict")  # type: ignore[arg-type]
+
+
+class TestClientSearch:
+    """Test Client.search wiring."""
+
+    def _client(self, response: dict) -> MagicMock:
+        from spicepy._client import Client
+
+        client = MagicMock(spec=Client)
+        client.http = MagicMock()
+        client.http.send_request.return_value = response
+        client.search = Client.search.__get__(client, Client)
+        return client
+
+    def test_posts_to_v1_search(self) -> None:
+        client = self._client({"results": [], "duration_ms": 3})
+        client.search("tickets to Tokyo", datasets=["app_messages"], limit=3)
+
+        args, kwargs = client.http.send_request.call_args
+        assert args[0] == "POST"
+        assert args[1] == "/v1/search"
+        assert kwargs["headers"] == {"Content-Type": "application/json"}
+
+        import json
+
+        assert json.loads(kwargs["body"]) == {
+            "text": "tickets to Tokyo",
+            "datasets": ["app_messages"],
+            "limit": 3,
+        }
+
+    def test_returns_decoded_response(self) -> None:
+        client = self._client(
+            {
+                "results": [{"dataset": "app_messages", "_score": 0.91}],
+                "duration_ms": 42,
+            }
+        )
+        response = client.search("tickets")
+
+        assert isinstance(response, SearchResponse)
+        assert response.duration_ms == 42
+        assert response.results[0].score == 0.91
+
+    def test_empty_text_raises_before_the_request(self) -> None:
+        client = self._client({})
+        with pytest.raises(SpiceAIError, match="search text is required"):
+            client.search("")
+        client.http.send_request.assert_not_called()
+
+    def test_options_are_keyword_only(self) -> None:
+        client = self._client({"results": [], "duration_ms": 0})
+        with pytest.raises(TypeError):
+            client.search("tickets", ["app_messages"])  # type: ignore[misc]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -218,3 +218,34 @@ class TestSearchErrorMessage:
     def test_missing_status_code(self) -> None:
         message = search_error_message(None, "something went wrong")
         assert "something went wrong" in message
+
+
+class TestDecodeRobustness:
+    """Malformed responses should fail loudly, not later."""
+
+    def test_non_dict_match_raises(self) -> None:
+        with pytest.raises(SpiceAIError, match="unexpected search match"):
+            SearchMatch.from_dict("not a match")
+
+    def test_non_list_results_raises(self) -> None:
+        with pytest.raises(SpiceAIError, match="unexpected search results"):
+            SearchResponse.from_dict({"results": "not a list"})
+
+    def test_non_mapping_fields_coerce_to_empty(self) -> None:
+        """A malformed field must not leave a str where a dict is documented."""
+        response = SearchResponse.from_dict(
+            {
+                "results": [{"dataset": "a", "_score": 0.5, "data": "garbage"}],
+                "duration_ms": 1,
+            }
+        )
+        assert response.results[0].data == {}
+
+    def test_non_integer_duration_falls_back_to_zero(self) -> None:
+        response = SearchResponse.from_dict({"results": [], "duration_ms": "soon"})
+        assert response.duration_ms == 0
+
+    def test_error_page_instead_of_results(self) -> None:
+        """A proxy or error page reaches this decoder as readily as a result."""
+        with pytest.raises(SpiceAIError, match="unexpected search response"):
+            SearchResponse.from_dict("<html>502 Bad Gateway</html>")


### PR DESCRIPTION
## What

Adds `Client.search()`, wrapping the runtime's `POST /v1/search` — vector similarity, keyword, and hybrid search over datasets with an embedding column.

```python
response = client.search("tickets to Tokyo", datasets=["app_messages"], limit=3)

for match in response:
    print(match.dataset, match.score, match.matches)
```

`text` is the only positional argument; `datasets`, `limit`, `where`, `additional_columns` and `keywords` are keyword-only. Setting `keywords` pre-filters the embedding column with a lexical search before the vector search runs, making the search hybrid.

New public exports: `SearchResponse` and `SearchMatch`, with the implementation in a private `_search` module.

## Why

`/v1/search` works on a default `spice run` and is a distinctive Spice capability, but Python users had no way to reach it short of hand-rolling the HTTP call. spice.js is currently the only SDK that exposes it.

Two wire-format details `SearchMatch` handles so callers don't have to:

- the similarity score is serialized as `_score`, not `score`
- `data`, `primary_key` and `metadata` are omitted entirely when empty, so they default to `{}` rather than `None` — readable without a guard

Part of aligning search support across the SDKs.

## Verification

- [x] Unit tests pass — 16 new tests in `tests/test_search.py` covering body construction, wire-format decoding, and client wiring. Full unit run: 395 passed.
- [x] `make lint` — ruff clean; pylint 9.23/10 against the repo's `--fail-under=8.0` gate
- [x] `make type-check` — mypy reports no issues
- [x] `ruff format` clean on the new module
- [x] Verified against a live `spice run`: the search request reaches `/v1/search`, and a failure
      surfaces the runtime's own message rather than a bare `400 Client Error`
- [ ] A search returning matches was not exercised end to end — that needs a dataset with an embedding
      column and a loaded embedding model, which this environment has no credentials for. The 8
      `tests/test_main.py` failures in a full run are refused Flight connections and are unrelated.

Note: `make format-check` fails on 15 files on `trunk` already; this branch does not add to that set.
