### PR TITLE
ci: unbreak CI — inline the test dataset, and ignore PLR0917 from ruff 0.16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,15 +135,34 @@ jobs:
         run: |
           spice init spice_qs
           cd spice_qs
-          spice add spiceai/quickstart
+          # Define the dataset inline instead of `spice add spiceai/quickstart`.
+          # Pulling it from the Spicepod registry made every PR's integration tests
+          # depend on a remote service, and when that service started returning a
+          # JSON error body under `Content-Type: application/zip`, every open PR
+          # failed at once on "Failed to extract Spicepod archive: Could not find
+          # EOCD". This is the same dataset spiceai/quickstart defines.
+          cat >> spicepod.yaml <<'YAML'
+
+          datasets:
+            - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+              name: taxi_trips
+              description: taxi trips in s3
+              params:
+                file_format: parquet
+              acceleration:
+                enabled: true
+          YAML
           spiced &> spice.log &
-          # Wait for runtime to be ready (poll /v1/ready endpoint)
-          for i in {1..60}; do
-            if curl -s http://localhost:8090/v1/ready > /dev/null 2>&1; then
-              echo "Spice runtime is ready"
+          # Wait until the dataset is queryable, not merely until the runtime is up:
+          # /v1/ready returns before an accelerated dataset finishes loading, which
+          # races the tests into "table 'taxi_trips' not found".
+          for i in {1..120}; do
+            if curl -s -X POST http://localhost:8090/v1/sql \
+                 -d 'SELECT count(*) AS n FROM taxi_trips' 2>/dev/null | grep -q '"n"'; then
+              echo "Spice runtime is ready and taxi_trips is queryable"
               break
             fi
-            echo "Waiting for Spice runtime to be ready... ($i/60)"
+            echo "Waiting for Spice runtime and taxi_trips... ($i/120)"
             sleep 1
           done
 
@@ -154,20 +173,32 @@ jobs:
           export PATH="$HOME/.spice/bin:$PATH"
           spice init spice_qs
           cd spice_qs
-          spice add spiceai/quickstart
+          # Inline dataset rather than a registry fetch — see the non-Windows step.
+          cat >> spicepod.yaml <<'YAML'
+
+          datasets:
+            - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+              name: taxi_trips
+              description: taxi trips in s3
+              params:
+                file_format: parquet
+              acceleration:
+                enabled: true
+          YAML
           nohup spiced > spice.log 2>&1 &
-          # Wait for runtime to be ready (poll /v1/ready endpoint)
-          for i in $(seq 1 120); do
-            if curl -s http://localhost:8090/v1/ready > /dev/null 2>&1; then
-              echo "Spice runtime is ready"
+          # Wait until the dataset is queryable — see the non-Windows step.
+          for i in $(seq 1 180); do
+            if curl -s -X POST http://localhost:8090/v1/sql \
+                 -d 'SELECT count(*) AS n FROM taxi_trips' 2>/dev/null | grep -q '"n"'; then
+              echo "Spice runtime is ready and taxi_trips is queryable"
               exit 0
             fi
-            echo "Waiting for Spice runtime to be ready... ($i/120)"
+            echo "Waiting for Spice runtime and taxi_trips... ($i/180)"
             sleep 1
           done
           echo "=== spice log ==="
           cat spice.log || true
-          echo "Spice runtime did not become ready within 120 seconds"
+          echo "taxi_trips did not become queryable within 180 seconds"
           exit 1
 
       # The Windows readiness poll above runs inside WSL and only checks the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,10 @@ ignore = [
     "ANN205", # Missing return type annotation for staticmethod
     "ANN206", # Missing return type annotation for classmethod
     "PLR0913", # Too many arguments in function definition
+    "PLR0917", # Too many positional arguments (stabilized in ruff 0.16; the
+               # positional counterpart of PLR0913, already ignored above.
+               # Satisfying it would mean making existing client constructor
+               # parameters keyword-only, which is a breaking API change.)
     "PLR0911", # Too many return statements
     "PLR0915", # Too many statements
     "S101",   # Use of assert detected (needed for tests)


### PR DESCRIPTION
Every open PR is red, on two independent causes — neither of them anything the PRs changed. A dependabot bump (#159) and a release-prep branch (#155) fail identically to the feature branches.

## Cause 1 — the Spicepod registry serves a broken archive

```
Getting Spicepod spiceai/quickstart ...
ERROR Invalid argument: Failed to extract Spicepod archive: invalid Zip archive: Could not find EOCD
```

`api.spicerack.org` returns the quickstart Spicepod with **HTTP 200** and `Content-Type: application/zip`, but the body is a 152-byte JSON error:

```json
{"Message":"invalid path \"spiceaiquickstartv0.1.0<sha>\": selected encoding not supported","Code":0,"Type":"error"}
```

so the CLI unzips an error message. Reproduces locally with the released CLI, identical under every `Accept-Encoding` (`identity` / `gzip` / `deflate` / none), and served with `cache-control: public, max-age=5184000`. Deterministic — not a flake that retrying clears.

**The registry bug should be fixed separately**; this PR only stops CI depending on it.

`spice add spiceai/quickstart` supplied exactly one dataset, and the integration job runs `-k "not cloud"`, so `taxi_trips` is all it needs — the `tpch` tables belong to the cloud tests. Defining it inline removes a shared remote dependency that can, and did, fail every PR at once.

Also waits until `taxi_trips` is queryable rather than until `/v1/ready` returns. `/v1/ready` answers before an accelerated dataset finishes loading — locally it passed at 2s against a load completing at 11s — which races the tests into `table 'taxi_trips' not found`.

## Cause 2 — ruff 0.16 stabilized PLR0917

The lint job installs from `ruff>=0.15.12`, so it took 0.16.0 the moment it released. 0.16 stabilizes `PLR0917` (too many positional arguments), which existing client constructors violate at `spicepy/_client.py:239` and `:332` — failing lint on every PR regardless of content.

`PLR0913`, the "too many arguments" counterpart, is **already** in the ignore list, so this codebase has an established position on wide signatures. Satisfying `PLR0917` instead would mean making constructor parameters keyword-only — a breaking change for a published SDK.

## Verification

Ran the rendered CI steps locally against an isolated runtime:

- inline pod loads **2,964,624 rows** from the public `spiceai-demo-datasets` bucket — the same data quickstart provides
- readiness gate passed at 11s, after the load rather than before it
- `pytest tests/test_main.py -k "not cloud"` → **12 passed**
- `ruff@0.16.0 check spicepy tests` → 2 errors before, clean after; 0.15.12 still clean
- `black --check` and `pylint` unaffected

## Unblocks

#175, #174, #173, #172, #159, #155 — all failing on cause 1, and all would hit cause 2 on any re-run. They need trunk merged in once this lands.

## Not covered here

`Cloud tests` fails separately with `UNAUTHENTICATED: [FlightSQL] API key not found` — the `API_KEY` secret is rejected, not merely absent. That needs the key rotated; dependabot PRs additionally never receive secrets.
