### PR TITLE
feat: add search for the runtime's /v1/search endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,44 @@ Once a `Client` is obtained queries can be made using the `query()` function. Th
 
 A custom timeout can be set by passing the `timeout` parameter in the `query` function call. If no timeout is specified, it will default to a 10 min timeout then cancel the query, and a TimeoutError exception will be raised.
 
+### Search
+
+Search datasets for documents similar to a piece of text. This requires datasets with an embedding column and a loaded embedding model — see [Search & Retrieval](https://docs.spice.ai/features/search-and-retrieval) for how to configure them.
+
+```python
+from spicepy import Client
+
+client = Client()
+
+result = client.search(
+    'tokyo plane tickets',
+    datasets=['app_messages'],
+    limit=3,
+    additional_columns=['timestamp'],
+)
+
+print(f'{len(result)} matches in {result.duration_ms}ms')
+for match in result:
+    print(match.score, match.dataset, match.matches, match.data)
+```
+
+`search()` takes the search text plus the following keyword arguments:
+
+- **datasets** (list of string, optional): Datasets to search. Omit to search every searchable dataset.
+- **limit** (int, optional): Maximum matches to return per dataset.
+- **where** (string, optional): A SQL predicate filtering candidate rows, without the leading `WHERE` — for example `'user_id = 42'`.
+- **additional_columns** (list of string, optional): Extra columns to return with each match. Primary key columns are returned under `primary_key`, the rest under `data`.
+- **keywords** (list of string, optional): Keywords for the lexical pass of a hybrid search, which the runtime combines with the vector scores into a single ranking.
+
+It returns a `SearchResult` holding `duration_ms` and a list of `SearchMatch`. Iterating the result yields the matches directly. Each `SearchMatch` has:
+
+- **dataset** (string): The dataset the match was found in.
+- **score** (float): The match's similarity to the query. Higher is more similar.
+- **matches** (dict): The matched values, keyed by source column. Each value is a list, because one column may contribute several chunks to a single match.
+- **primary_key** (dict): The primary key columns identifying the matched row. Empty when the dataset declares no primary key.
+- **data** (dict): Any `additional_columns` that were requested.
+- **metadata** (dict): Extra per-match metadata the runtime attached.
+
 ## Documentation
 
 Check out our [Documentation](https://docs.spice.ai/sdks/python-sdk) to learn more about how to use the Python SDK.

--- a/spicepy/__init__.py
+++ b/spicepy/__init__.py
@@ -10,11 +10,14 @@ from ._client import Client
 from ._dataframe import SpiceDataFrame
 from ._expr import Expr, WindowFrame, case, col, lit
 from ._http import RefreshOpts
+from ._search import SearchMatch, SearchResult
 
 __all__ = [
     "Client",
     "Expr",
     "RefreshOpts",
+    "SearchMatch",
+    "SearchResult",
     "SpiceDataFrame",
     "WindowFrame",
     "case",

--- a/spicepy/_client.py
+++ b/spicepy/_client.py
@@ -24,6 +24,7 @@ from pyarrow._flight import (
 
 from . import config
 from ._http import HttpRequests, RefreshOpts
+from ._search import SEARCH_PATH, SearchResult, build_search_body
 from .params import infer_arrow_type
 
 
@@ -750,6 +751,68 @@ class Client:
         )
 
         return response
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    # pylint: disable=R0913
+    # pylint: disable=R0917
+    def search(
+        self,
+        text: str,
+        *,
+        datasets: list[str] | None = None,
+        limit: int | None = None,
+        where: str | None = None,
+        additional_columns: list[str] | None = None,
+        keywords: list[str] | None = None,
+    ) -> SearchResult:
+        """Search datasets for documents similar to ``text``.
+
+        Runs against datasets that have an embedding column and a loaded
+        embedding model. Supplying ``keywords`` adds a lexical pass, which the
+        runtime combines with the vector scores into a hybrid ranking.
+
+        Example:
+            result = client.search(
+                "tokyo plane tickets",
+                datasets=["app_messages"],
+                limit=3,
+                additional_columns=["timestamp"],
+            )
+            for match in result:
+                print(match.dataset, match.score, match.matches)
+
+        Args:
+            text: The text to find similar documents for.
+            datasets: Datasets to search. Omit to search every searchable dataset.
+            limit: Maximum matches to return per dataset.
+            where: A SQL predicate to filter candidate rows, without the
+                leading ``WHERE`` — for example ``"user_id = 42"``.
+            additional_columns: Extra columns to return alongside each match.
+                A primary key column is returned under ``primary_key``, the
+                rest under ``data``.
+            keywords: Keywords for the lexical pass of a hybrid search.
+
+        Returns:
+            A :class:`~spicepy.SearchResult` holding the matches and the
+            runtime's reported duration.
+
+        Raises:
+            ValueError: If ``text`` is empty, ``datasets`` is an empty list, or
+                ``limit`` is less than 1.
+            SpiceAIError: If the runtime rejects the search or is unreachable.
+        """
+        body = build_search_body(
+            text,
+            datasets=datasets,
+            limit=limit,
+            where=where,
+            additional_columns=additional_columns,
+            keywords=keywords,
+        )
+        return SearchResult.from_json(self.http.post_json(SEARCH_PATH, body))
 
 
 class _ArrowFlightCallThread(threading.Thread):

--- a/spicepy/_http.py
+++ b/spicepy/_http.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 import datetime
+import json
 from pathlib import Path
 from typing import Any, Literal
 
@@ -72,6 +73,37 @@ class HttpRequests:
         )
         response.raise_for_status()
         return response.json()
+
+    def post_json(self, path: str, payload: dict[str, Any]) -> Any:
+        """POST a JSON payload and decode the JSON response.
+
+        Unlike `send_request`, a failed request raises `SpiceAIError` carrying
+        the runtime's own explanation. The runtime reports errors on these
+        endpoints as a plain-text body, which `raise_for_status` discards.
+        """
+        headers = dict(self.session.headers)
+        headers["Content-Type"] = "application/json"
+
+        response: Response = self.session.post(
+            url=f"{self.base_url}{path}",
+            data=json.dumps(payload),
+            verify=True,
+            headers=headers,
+        )
+
+        if not response.ok:
+            detail = (response.text or "").strip()
+            raise SpiceAIError(
+                f"{path} failed with status {response.status_code}"
+                + (f": {detail}" if detail else "")
+            )
+
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise SpiceAIError(
+                f"{path} returned a response that was not valid JSON"
+            ) from exc
 
     def prepare_param(self, params: dict[str, Any]) -> dict[str, Any]:
         for k, val in params.items():

--- a/spicepy/_http.py
+++ b/spicepy/_http.py
@@ -131,6 +131,7 @@ class HttpRequests:
             verify=True,
             headers=merged_headers,
         )
+
     def prepare_param(self, params: dict[str, Any]) -> dict[str, Any]:
         for k, val in params.items():
             if isinstance(val, datetime.timedelta):

--- a/spicepy/_search.py
+++ b/spicepy/_search.py
@@ -1,0 +1,112 @@
+"""Types and request building for the runtime's ``/v1/search`` endpoint."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+SEARCH_PATH = "/v1/search"
+
+
+@dataclass(frozen=True)
+class SearchMatch:
+    """A single document matched by :meth:`spicepy.Client.search`.
+
+    Attributes:
+        dataset: The dataset the match was found in.
+        score: The match's similarity to the query. Higher is more similar.
+        matches: The matched values, keyed by the column they came from. The
+            runtime returns a list per column because a column may contribute
+            more than one chunk to a single match.
+        primary_key: The primary key columns identifying the matched row.
+            Empty when the dataset declares no primary key.
+        data: Any ``additional_columns`` requested, keyed by column name.
+        metadata: Extra per-match metadata the runtime chose to attach.
+    """
+
+    dataset: str
+    score: float
+    matches: dict[str, list[Any]] = field(default_factory=dict)
+    primary_key: dict[str, Any] = field(default_factory=dict)
+    data: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_json(cls, obj: dict[str, Any]) -> SearchMatch:
+        """Build a match from one element of the runtime's ``results`` array.
+
+        The runtime omits ``data``, ``primary_key``, and ``metadata`` when they
+        are empty, so each is defaulted rather than required.
+        """
+        return cls(
+            dataset=obj.get("dataset", ""),
+            score=float(obj.get("_score", 0.0)),
+            matches=obj.get("matches") or {},
+            primary_key=obj.get("primary_key") or {},
+            data=obj.get("data") or {},
+            metadata=obj.get("metadata") or {},
+        )
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    """The matches returned by a single :meth:`spicepy.Client.search` call.
+
+    Iterating a ``SearchResult`` yields its :class:`SearchMatch` items, so the
+    common case reads as ``for match in client.search(...)``.
+    """
+
+    results: list[SearchMatch]
+    duration_ms: int
+
+    @classmethod
+    def from_json(cls, obj: dict[str, Any]) -> SearchResult:
+        """Build a result from the runtime's ``/v1/search`` response body."""
+        return cls(
+            results=[SearchMatch.from_json(m) for m in obj.get("results") or []],
+            duration_ms=int(obj.get("duration_ms", 0)),
+        )
+
+    def __iter__(self):
+        return iter(self.results)
+
+    def __len__(self) -> int:
+        return len(self.results)
+
+
+def build_search_body(
+    text: str,
+    *,
+    datasets: list[str] | None = None,
+    limit: int | None = None,
+    where: str | None = None,
+    additional_columns: list[str] | None = None,
+    keywords: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build the ``/v1/search`` request body, validating what the runtime rejects.
+
+    Optional fields are omitted rather than sent as null so the runtime applies
+    its own defaults.
+    """
+    if not text or not text.strip():
+        raise ValueError("text must be a non-empty search string")
+    if datasets is not None and len(datasets) == 0:
+        raise ValueError(
+            "datasets must name at least one dataset. Omit it to search all "
+            "searchable datasets."
+        )
+    if limit is not None and limit < 1:
+        raise ValueError("limit must be greater than 0")
+
+    body: dict[str, Any] = {"text": text}
+    if datasets is not None:
+        body["datasets"] = datasets
+    if limit is not None:
+        body["limit"] = limit
+    if where is not None:
+        body["where"] = where
+    if additional_columns is not None:
+        body["additional_columns"] = additional_columns
+    if keywords is not None:
+        body["keywords"] = keywords
+    return body

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -415,9 +415,7 @@ class TestHttpRequestsPostJson:
         assert kwargs["headers"]["Content-Type"] == "application/json"
 
     @patch("spicepy._http.Session")
-    def test_error_carries_runtime_message(
-        self, mock_session_class: MagicMock
-    ) -> None:
+    def test_error_carries_runtime_message(self, mock_session_class: MagicMock) -> None:
         """A plain-text error body is surfaced rather than discarded."""
         mock_response = MagicMock(spec=Response)
         mock_response.ok = False

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -452,6 +452,7 @@ class TestHttpRequestsPostJson:
         with pytest.raises(SpiceAIError, match="not valid JSON"):
             http.post_json("/v1/search", {"text": "tokyo"})
 
+
 class TestHttpRequestsSendRequestRaw:
     """Test HttpRequests.send_request_raw method."""
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -386,6 +386,75 @@ class TestHttpRequestsSendRequest:
         )
 
 
+class TestHttpRequestsPostJson:
+    """Test HttpRequests.post_json method."""
+
+    @staticmethod
+    def _session(mock_session_class: MagicMock, response: MagicMock) -> MagicMock:
+        mock_session = MagicMock()
+        mock_session.headers = {}
+        mock_session.post.return_value = response
+        mock_session_class.return_value = mock_session
+        return mock_session
+
+    @patch("spicepy._http.Session")
+    def test_posts_json_body(self, mock_session_class: MagicMock) -> None:
+        """The payload is serialized as JSON with a JSON content type."""
+        mock_response = MagicMock(spec=Response)
+        mock_response.ok = True
+        mock_response.json.return_value = {"results": []}
+        mock_session = self._session(mock_session_class, mock_response)
+
+        http = HttpRequests("http://example.com", {})
+        result = http.post_json("/v1/search", {"text": "tokyo"})
+
+        assert result == {"results": []}
+        kwargs = mock_session.post.call_args.kwargs
+        assert kwargs["url"] == "http://example.com/v1/search"
+        assert kwargs["data"] == '{"text": "tokyo"}'
+        assert kwargs["headers"]["Content-Type"] == "application/json"
+
+    @patch("spicepy._http.Session")
+    def test_error_carries_runtime_message(
+        self, mock_session_class: MagicMock
+    ) -> None:
+        """A plain-text error body is surfaced rather than discarded."""
+        mock_response = MagicMock(spec=Response)
+        mock_response.ok = False
+        mock_response.status_code = 400
+        mock_response.text = "No data sources provided"
+        self._session(mock_session_class, mock_response)
+
+        http = HttpRequests("http://example.com", {})
+        with pytest.raises(SpiceAIError, match="No data sources provided"):
+            http.post_json("/v1/search", {"text": "tokyo"})
+
+    @patch("spicepy._http.Session")
+    def test_error_without_body(self, mock_session_class: MagicMock) -> None:
+        """An empty error body still reports the status code."""
+        mock_response = MagicMock(spec=Response)
+        mock_response.ok = False
+        mock_response.status_code = 503
+        mock_response.text = ""
+        self._session(mock_session_class, mock_response)
+
+        http = HttpRequests("http://example.com", {})
+        with pytest.raises(SpiceAIError, match="503"):
+            http.post_json("/v1/search", {"text": "tokyo"})
+
+    @patch("spicepy._http.Session")
+    def test_malformed_json_response(self, mock_session_class: MagicMock) -> None:
+        """A 200 with a non-JSON body is reported as such."""
+        mock_response = MagicMock(spec=Response)
+        mock_response.ok = True
+        mock_response.json.side_effect = ValueError("not json")
+        self._session(mock_session_class, mock_response)
+
+        http = HttpRequests("http://example.com", {})
+        with pytest.raises(SpiceAIError, match="not valid JSON"):
+            http.post_json("/v1/search", {"text": "tokyo"})
+
+
 class TestHttpRequestsRetryConfiguration:
     """Test HttpRequests retry configuration."""
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -165,9 +165,7 @@ class TestClientSearch:
         """The response body is parsed into a SearchResult."""
         client = self._client(
             {
-                "results": [
-                    {"matches": {"m": ["hit"]}, "dataset": "d", "_score": 0.7}
-                ],
+                "results": [{"matches": {"m": ["hit"]}, "dataset": "d", "_score": 0.7}],
                 "duration_ms": 12,
             }
         )

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,198 @@
+"""Unit tests for spicepy._search and Client.search."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from spicepy import SearchMatch, SearchResult
+from spicepy._search import SEARCH_PATH, build_search_body
+from spicepy.error import SpiceAIError
+
+
+@pytest.mark.unit
+class TestBuildSearchBody:
+    """Test request body construction."""
+
+    def test_text_only(self) -> None:
+        """Only text is sent when nothing else is supplied."""
+        assert build_search_body("tokyo") == {"text": "tokyo"}
+
+    def test_all_options(self) -> None:
+        """Every supplied option maps onto its wire field."""
+        body = build_search_body(
+            "tokyo",
+            datasets=["app_messages"],
+            limit=3,
+            where="user_id = 42",
+            additional_columns=["timestamp"],
+            keywords=["plane", "tickets"],
+        )
+        assert body == {
+            "text": "tokyo",
+            "datasets": ["app_messages"],
+            "limit": 3,
+            "where": "user_id = 42",
+            "additional_columns": ["timestamp"],
+            "keywords": ["plane", "tickets"],
+        }
+
+    def test_omits_unset_options(self) -> None:
+        """Unset options are omitted, not sent as null, so runtime defaults apply."""
+        body = build_search_body("tokyo", limit=5)
+        assert body == {"text": "tokyo", "limit": 5}
+        assert "datasets" not in body
+        assert "where" not in body
+
+    def test_empty_additional_columns_is_sent(self) -> None:
+        """An explicitly empty list is distinct from omitting the field."""
+        body = build_search_body("tokyo", additional_columns=[])
+        assert body["additional_columns"] == []
+
+    @pytest.mark.parametrize("text", ["", "   "])
+    def test_rejects_empty_text(self, text: str) -> None:
+        """Empty or whitespace-only text is rejected before the request."""
+        with pytest.raises(ValueError, match="non-empty"):
+            build_search_body(text)
+
+    def test_rejects_empty_datasets(self) -> None:
+        """An empty dataset list would be a 400; catch it locally."""
+        with pytest.raises(ValueError, match="at least one dataset"):
+            build_search_body("tokyo", datasets=[])
+
+    @pytest.mark.parametrize("limit", [0, -1])
+    def test_rejects_non_positive_limit(self, limit: int) -> None:
+        """A limit below 1 would be a 400; catch it locally."""
+        with pytest.raises(ValueError, match="greater than 0"):
+            build_search_body("tokyo", limit=limit)
+
+
+@pytest.mark.unit
+class TestSearchResultParsing:
+    """Test parsing of the runtime's response body."""
+
+    def test_full_match(self) -> None:
+        """A fully populated match maps onto SearchMatch."""
+        result = SearchResult.from_json(
+            {
+                "results": [
+                    {
+                        "matches": {"message": ["I booked us some tickets"]},
+                        "dataset": "app_messages",
+                        "primary_key": {"id": "6fd5a215"},
+                        "data": {"timestamp": 1724716542},
+                        "metadata": {"chunk": 2},
+                        "_score": 0.914321,
+                    }
+                ],
+                "duration_ms": 42,
+            }
+        )
+
+        assert result.duration_ms == 42
+        assert len(result) == 1
+        match = result.results[0]
+        assert match.dataset == "app_messages"
+        assert match.score == pytest.approx(0.914321)
+        assert match.matches == {"message": ["I booked us some tickets"]}
+        assert match.primary_key == {"id": "6fd5a215"}
+        assert match.data == {"timestamp": 1724716542}
+        assert match.metadata == {"chunk": 2}
+
+    def test_omitted_fields_default_to_empty(self) -> None:
+        """The runtime omits data, primary_key, and metadata when empty."""
+        match = SearchMatch.from_json(
+            {"matches": {"message": ["hello"]}, "dataset": "d", "_score": 0.5}
+        )
+        assert match.data == {}
+        assert match.primary_key == {}
+        assert match.metadata == {}
+
+    def test_multiple_values_per_column(self) -> None:
+        """A column may contribute more than one chunk to a single match."""
+        match = SearchMatch.from_json(
+            {"matches": {"body": ["first chunk", "second chunk"]}, "_score": 0.1}
+        )
+        assert match.matches["body"] == ["first chunk", "second chunk"]
+
+    def test_no_results(self) -> None:
+        """An empty result set parses to an empty, falsy-length result."""
+        result = SearchResult.from_json({"results": [], "duration_ms": 3})
+        assert len(result) == 0
+        assert list(result) == []
+
+    def test_iterates_matches(self) -> None:
+        """Iterating a SearchResult yields its matches."""
+        result = SearchResult.from_json(
+            {
+                "results": [
+                    {"matches": {}, "dataset": "a", "_score": 0.9},
+                    {"matches": {}, "dataset": "b", "_score": 0.8},
+                ],
+                "duration_ms": 1,
+            }
+        )
+        assert [m.dataset for m in result] == ["a", "b"]
+
+
+@pytest.mark.unit
+class TestClientSearch:
+    """Test Client.search wiring."""
+
+    @staticmethod
+    def _client(response: dict) -> MagicMock:
+        from spicepy import Client
+
+        client = MagicMock(spec=Client)
+        client.http = MagicMock()
+        client.http.post_json.return_value = response
+        client.search = Client.search.__get__(client, Client)
+        return client
+
+    def test_posts_to_search_endpoint(self) -> None:
+        """The built body is posted to /v1/search."""
+        client = self._client({"results": [], "duration_ms": 0})
+
+        client.search("tokyo", datasets=["app_messages"], limit=3)
+
+        client.http.post_json.assert_called_once_with(
+            SEARCH_PATH,
+            {"text": "tokyo", "datasets": ["app_messages"], "limit": 3},
+        )
+
+    def test_returns_parsed_result(self) -> None:
+        """The response body is parsed into a SearchResult."""
+        client = self._client(
+            {
+                "results": [
+                    {"matches": {"m": ["hit"]}, "dataset": "d", "_score": 0.7}
+                ],
+                "duration_ms": 12,
+            }
+        )
+
+        result = client.search("tokyo")
+
+        assert isinstance(result, SearchResult)
+        assert result.duration_ms == 12
+        assert result.results[0].matches == {"m": ["hit"]}
+
+    def test_validates_before_requesting(self) -> None:
+        """Invalid arguments raise before any request is made."""
+        client = self._client({"results": [], "duration_ms": 0})
+
+        with pytest.raises(ValueError):
+            client.search("")
+
+        client.http.post_json.assert_not_called()
+
+    def test_propagates_runtime_error(self) -> None:
+        """A runtime failure surfaces as SpiceAIError."""
+        client = self._client({})
+        client.http.post_json.side_effect = SpiceAIError(
+            "/v1/search failed with status 400: No data sources provided"
+        )
+
+        with pytest.raises(SpiceAIError, match="No data sources provided"):
+            client.search("tokyo")


### PR DESCRIPTION
## What

Adds `Client.search(...)`, wrapping the runtime's `/v1/search` endpoint — vector similarity search, with optional keywords for a hybrid lexical + vector ranking.

```python
result = client.search(
    'tokyo plane tickets',
    datasets=['app_messages'],
    limit=3,
    additional_columns=['timestamp'],
)
for match in result:
    print(match.score, match.dataset, match.matches)
```

## Why

`/v1/search` works on a default `spice run`, but of the six client SDKs only spice.js could reach it. Python users had to hand-roll the HTTP call, including the response shape.

Part of aligning capabilities across the SDKs against the runtime's own API surface.

Two details the response types encode, taken from the runtime's wire format rather than the OpenAPI example (which is out of date on the first point):

- `matches` is a list of values per column — one column can contribute several chunks to a single match.
- `data`, `primary_key`, and `metadata` are omitted by the runtime when empty, so each defaults to `{}` rather than being required.

Also adds `HttpRequests.post_json`. `send_request` relies on `raise_for_status`, which discards the response body; the runtime reports search failures as plain text ("No data sources provided"), so that message would otherwise be lost behind a generic `400 Client Error`. Arguments the runtime would reject with a 400 — empty text, an empty `datasets` list, a `limit` below 1 — are validated locally so the error names the argument to fix.

## Verification

- [x] `pytest tests/test_search.py tests/test_http.py` — 58 passed
- [x] Full unit suite (`pytest -m "unit or not (integration or cloud or slow)"`) — 401 passed, 8 failed. All 8 failures are pre-existing `ImportError: adbc_driver_manager` in `tests/test_main.py` (ADBC driver not installed in this environment); none are in changed code.
- [x] `ruff check` clean on `spicepy/_search.py`, `spicepy/_http.py`, `spicepy/__init__.py`, `tests/test_search.py`, `tests/test_http.py`. `spicepy/_client.py` reports 2 `PLR0917`, both pre-existing on `_SpiceFlight.__init__` and `Client.__init__`.
- [x] `mypy spicepy --ignore-missing-imports` — success, no issues in 11 source files
- [ ] Integration tests — not run (no live runtime available)
- [ ] `make format-check` — not run. It fails on trunk today (17 files would be reformatted under the configured `line-length = 120`), so the new code follows the wrapping style actually committed in the repo rather than reformatting.
