### PR TITLE
fix(lint): ignore ruff PLR0917 so trunk passes ruff check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,8 @@ ignore = [
     "ANN205", # Missing return type annotation for staticmethod
     "ANN206", # Missing return type annotation for classmethod
     "PLR0913", # Too many arguments in function definition
+    "PLR0917", # Too many positional arguments: Client.__init__ is public API, so its
+               # parameters cannot become keyword-only without a breaking change
     "PLR0911", # Too many return statements
     "PLR0915", # Too many statements
     "S101",   # Use of assert detected (needed for tests)


### PR DESCRIPTION
`ruff check spicepy tests` — the command the `Lint with ruff` job runs — fails on **trunk itself** with two errors, so every open pull request inherits a red ruff job regardless of what it changes:

```
PLR0917 Too many positional arguments (6 > 5)
   --> spicepy/_client.py:239:9
PLR0917 Too many positional arguments (7 > 5)
   --> spicepy/_client.py:332:9
```

Verified against a clean checkout of trunk (`a199cfa`) with ruff 0.16.1: two errors, no branch involved.

### Why ignore rather than refactor

The lint config already ignores `PLR0913` ("Too many arguments in function definition"), and both flagged constructors carry an in-code `# pylint: disable=R0917` — pylint's name for this same rule. The decision to allow these signatures was already made and recorded in two places; only ruff's half of the pair was missing from `ignore`.

`Client.__init__` is the public SDK constructor. Satisfying the rule for real would mean making its parameters keyword-only, which breaks every caller that passes them positionally — not an acceptable trade for a lint warning the project has already opted out of under its pylint name.

### Test plan

- `ruff check spicepy tests` → `All checks passed!` (was: `Found 2 errors.`)
- `black --check spicepy tests` → unchanged, 22 files clean
- No source files touched; the change is two lines of lint configuration.