### PR TITLE
fix(lint): waive PLR0917 for the client constructors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,7 @@ ignore = [
 ]
 "spicepy/_client.py" = [
     "S608",   # SQL is constructed from escaped identifiers/literals; lint can't tell
+    "PLR0917", # Client constructors take many positional args; already waived for pylint (R0917)
 ]
 "spicepy/_dataframe.py" = [
     "S608",   # The DataFrame layer's entire job is composing SQL; identifiers and literals are escaped


### PR DESCRIPTION
## Problem

`ruff check spicepy tests` fails on **pristine trunk** (`a199cfa`, no local changes):

```
PLR0917 Too many positional arguments (6 > 5)  --> spicepy/_client.py:239:9
PLR0917 Too many positional arguments (7 > 5)  --> spicepy/_client.py:332:9
Found 2 errors.
```

Neither constructor has changed. ruff 0.16 stabilized `PLR0917`
(too-many-positional-arguments) out of preview, and `pyproject.toml` pins only a
lower bound (`ruff>=0.15.12`), so CI floated onto the new ruff and started
failing every PR.

## Why waiving is the right call here

Both shapes were already sanctioned explicitly:

- `Client.__init__` carries `# pylint: disable=R0917` — the *same rule* under pylint.
- `PLR0913` (its sibling, too-many-arguments) is already ignored project-wide.

The ruff config just missed the `R0917` → `PLR0917` translation; the gap stayed
invisible while the rule was in preview. This restores the policy the codebase
already documents rather than relaxing a new one.

Scoped to `per-file-ignores` for `_client.py`, not global, so `PLR0917` stays
active for new code. The alternative — making these params keyword-only — would
break callers of a published SDK's public constructors.

## Impact

Unblocks the ruff job on all open PRs, including #177 and #173, which fail this
lint on code they never touched.

## Follow-up (not in this PR)

`ruff>=0.15.12` has no upper bound, so a future ruff release can break CI again
with no code change. Worth pinning or adding a constraint — filed as #181.

## Verification

`ruff check spicepy tests` → `All checks passed!` (ruff 0.16.1)

