### PR TITLE
fix(test): require a credential before running the cloud tests

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -45,17 +45,32 @@ def wait_for_ready(
     return False
 
 
-# Skip cloud tests if TEST_SPICE_CLOUD is not set to true
+def cloud_api_key():
+    """The Spice.ai Cloud API key, or an empty string when none is available.
+
+    An empty value counts as absent, so an unusable key falls through to the next
+    source rather than being taken as the answer. `test.yml` passes the key as
+    `SPICE_API_KEY: ${{ secrets.SCP_SPICEAI_TPCH_API_KEY }}`, and a workflow run
+    that cannot read repository secrets - every pull request from a fork - renders
+    that expression as the empty string rather than leaving the variable unset.
+    """
+    return os.environ.get("SPICE_API_KEY") or os.environ.get("API_KEY") or ""
+
+
+# Skip cloud tests unless they are enabled and a credential is available to run them
 def skip_cloud():
-    skip = os.environ.get("TEST_SPICE_CLOUD") != "true"
+    enabled = os.environ.get("TEST_SPICE_CLOUD") == "true"
     return pytest.mark.skipif(
-        skip, reason="Cloud tests disabled (set TEST_SPICE_CLOUD=true)"
+        not (enabled and cloud_api_key()),
+        reason=(
+            "Cloud tests need TEST_SPICE_CLOUD=true and a non-empty "
+            "SPICE_API_KEY (or API_KEY)"
+        ),
     )
 
 
 def get_cloud_client():
-    api_key = os.environ.get("SPICE_API_KEY", os.environ.get("API_KEY", ""))
-    return Client(api_key=api_key, flight_url="grpc+tls://flight.spiceai.io")
+    return Client(api_key=cloud_api_key(), flight_url="grpc+tls://flight.spiceai.io")
 
 
 def get_local_client():


### PR DESCRIPTION
## What was wrong

The `pytest-cloud` job in `test.yml` hardcodes the enable flag and takes the credential from a secret:

```yaml
env:
  SPICE_API_KEY: ${{ secrets.SCP_SPICEAI_TPCH_API_KEY }}
  TEST_SPICE_CLOUD: 'true'
```

A workflow run that cannot read repository secrets — **every pull request from a fork** — renders `${{ secrets.… }}` as the **empty string** rather than leaving the variable unset. `skip_cloud()` only consulted `TEST_SPICE_CLOUD`, which is hardcoded `'true'`, so it saw the suite as enabled, an empty key reached the service, and all **24** cloud tests failed:

```
tests/test_main.py::test_flight_recent_blocks FAILED
tests/test_main.py::test_cloud_parameterized_query_basic FAILED
... 24 total
```

That is the only red check on #177, over a credential the run can never be given.

`get_cloud_client()` had the same present-but-empty blind spot from the other direction: `os.environ.get("SPICE_API_KEY", os.environ.get("API_KEY", ""))` uses `SPICE_API_KEY` whenever it is *present*, so an empty one was taken as the answer and the `API_KEY` fallback was never reached.

## What this does

- `cloud_api_key()` — one helper for the lookup, treating empty as absent, so an empty `SPICE_API_KEY` falls through to `API_KEY`.
- `skip_cloud()` now requires the enable flag **and** a usable credential, and says which in the skip reason.
- `get_cloud_client()` reads through the same helper, so the gate and the client can never disagree about whether a credential is available.

Scope is `tests/test_main.py` only; no workflow change, and no change to the local-runtime or unit tests.

Unlike the equivalent problem in the Rust SDK, pytest has a real runtime skip — these tests report as **skipped**, not as silently passing, so a credential-less run is visible in the log rather than looking like a clean pass.

## Verification

Run exactly as CI does (`pytest -s tests/test_main.py -k "cloud"`):

| Environment | Result | Exit |
|---|---|---|
| `SPICE_API_KEY=` (empty — the fork case), `TEST_SPICE_CLOUD=true` | `24 skipped, 12 deselected` | 0 |
| both unset, `TEST_SPICE_CLOUD=true` | `24 skipped, 12 deselected` | 0 |
| `SPICE_API_KEY=dummy`, `TEST_SPICE_CLOUD=true` | `24 failed` — tests **still run** and reach the service | 1 |
| `TEST_SPICE_CLOUD=false` | `24 skipped` (unchanged behavior) | 0 |

The third row is the load-bearing one: a present credential still runs all 24 for real, so this cannot mask a regression on any branch that can read the secret.

`ruff`, `flake8`, `black --check` clean; `pylint` 9.28/10 against a 8.0 floor.

## Note for whoever merges second

#155 rewrites the same `return Client(api_key=api_key, flight_url=…)` line in `get_cloud_client()` to make the flight URL configurable. The two changes do not disagree — that one changes the URL, this one changes where the key comes from — but they will collide textually. Merging both means keeping #155's `flight_url` lookup and this PR's `cloud_api_key()` call in the same `return`.
